### PR TITLE
Added type hints

### DIFF
--- a/muscima/cropobject.py
+++ b/muscima/cropobject.py
@@ -6,7 +6,7 @@ from __future__ import print_function, unicode_literals, division
 import copy
 import itertools
 import logging
-from typing import Any, Optional, List
+from typing import Any, Optional, List, Union, Tuple
 
 import numpy
 
@@ -535,6 +535,7 @@ class CropObject(object):
 
     @staticmethod
     def bbox_to_integer_bounds(ftop, fleft, fbottom, fright):
+        # type: (float,float,float,float) -> (int,int,int,int)
         """Rounds off the CropObject bounds to the nearest integer
         so that no area is lost (e.g. bottom and right bounds are
         rounded up, top and left bounds are rounded down).
@@ -609,6 +610,7 @@ class CropObject(object):
         return output
 
     def render(self, img, alpha=0.3, rgb=(1.0, 0.0, 0.0)):
+        # type: (numpy.ndarray, float, Tuple[float,float,float]) -> numpy.ndarray
         """Renders itself upon the given image as a rectangle
         of the given color and transparency. Might help visualization.
 
@@ -630,6 +632,7 @@ class CropObject(object):
         return img
 
     def overlaps(self, bounding_box_or_cropobject):
+        # type: (Union[Tuple[float,float,float,float],CropObject]) -> bool
         """Check whether this CropObject overlaps the given bounding box or CropObject.
 
         >>> c = CropObject(0, 'test', 10, 100, height=20, width=10)

--- a/muscima/cropobject.py
+++ b/muscima/cropobject.py
@@ -6,6 +6,7 @@ from __future__ import print_function, unicode_literals, division
 import copy
 import itertools
 import logging
+from typing import Any, Optional, List
 
 import numpy
 
@@ -14,8 +15,9 @@ from muscima.utils import compute_connected_components
 __version__ = "1.0"
 __author__ = "Jan Hajic jr."
 
-
 CROPOBJECT_MASK_ORDER = 'C'
+
+
 #: The CropObject mask uses this numpy ordering when flattening the data.
 
 ##############################################################################
@@ -242,11 +244,21 @@ class CropObject(object):
     (Also, the numpy array needs to be made C-contiguous for that, which
     explains the ``order='C'`` hack in ``set_mask()``.)
     """
-    def __init__(self, objid, clsname, top, left, width, height,
-                 outlinks=None, inlinks=None,
-                 mask=None,
-                 uid=None,
-                 data=None):
+
+    def __init__(self,
+                 objid,  # type: int
+                 clsname,  # type: str
+                 top,  # type: int
+                 left,  # type: int
+                 width,  # type: int
+                 height,  # type: int
+                 outlinks=None, # type: Optional[List[int]]
+                 inlinks=None,# type: Optional[List[int]]
+                 mask=None,  # type: numpy.ndarray
+                 uid=None, # type: str
+                 data=None
+                 ):
+        # type: (...) -> None
         # logging.debug('Initializing CropObject with objid {0}, uid {5}, x={1},'
         #              ' y={2}, h={3}, w={4}'
         #               ''.format(objid, top, left, height, width, uid))
@@ -279,7 +291,7 @@ class CropObject(object):
         self.set_uid(uid)
 
         self.is_selected = False
-        #logging.debug('...done!')
+        # logging.debug('...done!')
 
         if data is None:
             data = dict()
@@ -296,10 +308,12 @@ class CropObject(object):
     #: Default dataset name for CropObjects.
 
     UID_DEFAULT_DOCUMENT_NAMESPACE = 'default-document'
+
     #: Default document name for CropObjects.
 
     @property
     def default_uid(self):
+        # type: () -> str
         """Constructs the default ``uid`` that the CropObject would
         have, unless one was supplied at initialization.
 
@@ -311,6 +325,7 @@ class CropObject(object):
                                         str(self.objid)])
 
     def parse_uid(self):
+        # type: () -> (str, str, int)
         """Parse the unique identifier of the CropObject. This
         breaks down the UID into the global namespace, document
         namespace (ie. CropObjectList name -- usually per image),
@@ -321,26 +336,27 @@ class CropObject(object):
         the MUSCIMarker annotation app.
 
         See :meth:`_parse_uid` for format & test. Compared
-        to :meth:`_parse_uid`, this method checks the parsed ``num``
+        to :meth:`_parse_uid`, this method checks the parsed ``object_id``
         in the ``uid`` against this CropObject's ``objid``,
         to verify that the UID is really valid for this object.
 
         The delimiter is expected to be ``___``
         (kept as ``CropObject.UID_DELIMITER``)
         """
-        gn, dn, num = self._parse_uid(self.uid)
+        global_name, document_name, object_id = self._parse_uid(self.uid)
         # Dealing with missing uid
-        if num is None:
-            num = self.objid
+        if object_id is None:
+            object_id = self.objid
 
-        if num != self.objid:
+        if object_id != self.objid:
             raise ValueError('Got CropObject with different numeric ID'
                              ' in UID and technical objid. UID record:'
-                             ' {0}, objid: {1}'.format(num, self.objid))
-        return gn, dn, num
+                             ' {0}, objid: {1}'.format(object_id, self.objid))
+        return global_name, document_name, object_id
 
     @staticmethod
     def _parse_uid(uid):
+        # type: (Optional[str]) -> (str, str, int)
         """Parse the unique identifier of the CropObject. This
         breaks down the UID into the global namespace, document
         namespace (ie. CropObjectList name -- usually per image),
@@ -360,11 +376,11 @@ class CropObject(object):
         if uid is None:
             global_name = CropObject.UID_DEFAULT_DATASET_NAMESPACE
             document_name = CropObject.UID_DEFAULT_DOCUMENT_NAMESPACE
-            numid = None
+            object_id = None
         else:
             global_name, document_name, numid_str = uid.split(CropObject.UID_DELIMITER)
-            numid = int(numid_str)
-        return global_name, document_name, numid
+            object_id = int(numid_str)
+        return global_name, document_name, object_id
 
     @staticmethod
     def build_uid(global_name, document_name, numid):
@@ -409,7 +425,7 @@ class CropObject(object):
             t, l, b, r = self.bbox_to_integer_bounds(self.top,
                                                      self.left,
                                                      self.bottom,
-                                                     self.right)#.count()
+                                                     self.right)  # .count()
             if mask.shape != (b - t, r - l):
                 raise ValueError('Mask shape {0} does not correspond'
                                  ' to integer shape {1} of CropObject.'
@@ -741,31 +757,31 @@ class CropObject(object):
         # How many rows/columns to trim from top, bottom, etc.
         trim_top = -1
         for i in range(self.mask.shape[0]):
-            if self.mask[i,:].sum() != 0:
+            if self.mask[i, :].sum() != 0:
                 trim_top = i
                 break
 
         trim_left = -1
         for j in range(self.mask.shape[1]):
-            if self.mask[:,j].sum() != 0:
+            if self.mask[:, j].sum() != 0:
                 trim_left = j
                 break
 
         trim_bottom = -1
         for k in range(self.mask.shape[0]):
-            if self.mask[-(k+1),:].sum() != 0:
+            if self.mask[-(k + 1), :].sum() != 0:
                 trim_bottom = k
                 break
 
         trim_right = -1
         for l in range(self.mask.shape[1]):
-            if self.mask[:,-(l+1)].sum() != 0:
+            if self.mask[:, -(l + 1)].sum() != 0:
                 trim_right = l
                 break
 
         logging.debug('Cropobject.crop: Trimming top={0}, left={1},'
-                     'bottom={2}, right={3}'
-                     ''.format(trim_top, trim_left, trim_bottom, trim_right))
+                      'bottom={2}, right={3}'
+                      ''.format(trim_top, trim_left, trim_bottom, trim_right))
 
         # new bounding box relative to the current bounding box -- used to trim
         # the mask
@@ -777,7 +793,7 @@ class CropObject(object):
         new_mask = self.mask[rel_t:rel_b, rel_l:rel_r] * 1
 
         logging.debug('Cropobject.crop: Old mask shape {0}, new mask shape {1}'
-                     ''.format(self.mask.shape, new_mask.shape))
+                      ''.format(self.mask.shape, new_mask.shape))
 
         # new bounding box, relative to image -- used to compute the CropObject's
         # new position and size
@@ -851,8 +867,10 @@ class CropObject(object):
             elif isinstance(v, list):
                 vtype = 'list[str]'
                 if len(v) > 0:
-                    if isinstance(v[0], int): vtype='list[int]'
-                    elif isinstance(v[0], float): vtype='list[float]'
+                    if isinstance(v[0], int):
+                        vtype = 'list[int]'
+                    elif isinstance(v[0], float):
+                        vtype = 'list[float]'
                 vval = ' '.join([str(vv) for vv in v])
 
             line = '\t\t<DataItem key="{0}" type="{1}">{2}</DataItem>' \
@@ -952,9 +970,9 @@ class CropObject(object):
             logging.info('CropObject.decode_mask(): Cannot decode mask values:\n{0}'.format(mask_string))
             raise
         mask = numpy.array(values).reshape(shape)
-        #s = base64.decodestring(mask_string)
-        #mask = numpy.frombuffer(s)
-        #logging.info('CropObject.decode_mask(): shape={0}\nmask={1}'.format(mask.shape, mask))
+        # s = base64.decodestring(mask_string)
+        # mask = numpy.frombuffer(s)
+        # logging.info('CropObject.decode_mask(): shape={0}\nmask={1}'.format(mask.shape, mask))
         return mask
 
     @staticmethod
@@ -1011,8 +1029,8 @@ class CropObject(object):
         opl = other.left - nl
 
         # Paste the masks into these places
-        new_mask[spt:spt+self.height, spl:spl+self.width] += self.mask
-        new_mask[opt:opt+other.height, opl:opl+other.width] += other.mask
+        new_mask[spt:spt + self.height, spl:spl + self.width] += self.mask
+        new_mask[opt:opt + other.height, opl:opl + other.width] += other.mask
 
         # Normalize mask value
         new_mask[new_mask != 0] = 1
@@ -1247,12 +1265,12 @@ def cropobjects_merge_mask(cropobjects, intersection=False):
     h = b - t
     w = r - l
     output_mask = numpy.zeros((h, w), dtype=cropobjects[0].mask.dtype)
-    #logging.warn('Output mask shape: {0}'.format(output_mask.shape))
+    # logging.warn('Output mask shape: {0}'.format(output_mask.shape))
     for c in cropobjects:
-        #logging.debug('C. shape: {0}'.format(c.bounding_box))
-        #logging.debug('TLBR: {0}'.format((t, l, b, r)))
+        # logging.debug('C. shape: {0}'.format(c.bounding_box))
+        # logging.debug('TLBR: {0}'.format((t, l, b, r)))
         ct, cl, cb, cr = c.top - t, c.left - l, h - (b - c.bottom), w - (r - c.right)
-        #logging.debug('Mask shape: {0}, curr. shape: {1}'.format(c.mask.shape, (cb - ct, cr - cl)))
+        # logging.debug('Mask shape: {0}, curr. shape: {1}'.format(c.mask.shape, (cb - ct, cr - cl)))
         output_mask[ct:cb, cl:cr] += c.mask
 
     if intersection:
@@ -1360,10 +1378,10 @@ def link_cropobjects(fr, to, check_docname=True):
                             ''.format(fr.doc, to.doc))
 
     if (to.objid not in fr.outlinks) and (fr.objid in to.inlinks):
-            logging.warning('Malformed object graph in document {0}:'
-                            ' Relationship {1} --> {2} already exists as inlink,'
-                            ' but not as outlink!.'
-                            ''.format(fr.doc, fr.objid, to.objid))
+        logging.warning('Malformed object graph in document {0}:'
+                        ' Relationship {1} --> {2} already exists as inlink,'
+                        ' but not as outlink!.'
+                        ''.format(fr.doc, fr.objid, to.objid))
     fr.outlinks.append(to.objid)
     to.inlinks.append(fr.objid)
 
@@ -1437,8 +1455,8 @@ def cropobject_distance(c, d):
     separately, and the euclidean norm is computed from them."""
     if c.doc != d.doc:
         logging.warning('Cannot compute distances between CropObjects'
-                         ' from different documents! ({0} vs. {1})'
-                         ''.format(c.doc, d.doc))
+                        ' from different documents! ({0} vs. {1})'
+                        ''.format(c.doc, d.doc))
 
     c_t, c_l, c_b, c_r = c.bounding_box
     d_t, d_l, d_b, d_r = d.bounding_box

--- a/muscima/cropobject.py
+++ b/muscima/cropobject.py
@@ -248,14 +248,14 @@ class CropObject(object):
     def __init__(self,
                  objid,  # type: int
                  clsname,  # type: str
-                 top,  # type: int
-                 left,  # type: int
-                 width,  # type: int
-                 height,  # type: int
-                 outlinks=None, # type: Optional[List[int]]
-                 inlinks=None,# type: Optional[List[int]]
+                 top,  # type: float
+                 left,  # type: float
+                 width,  # type: float
+                 height,  # type: float
+                 outlinks=None,  # type: Optional[List[int]]
+                 inlinks=None,  # type: Optional[List[int]]
                  mask=None,  # type: numpy.ndarray
-                 uid=None, # type: str
+                 uid=None,  # type: str
                  data=None
                  ):
         # type: (...) -> None
@@ -404,6 +404,7 @@ class CropObject(object):
             self.parse_uid()
 
     def set_doc(self, docname):
+        # type: (str) -> None
         new_uid = self.UID_DELIMITER.join([self._dataset_namespace,
                                            docname,
                                            str(self._instance)])

--- a/muscima/cropobject.py
+++ b/muscima/cropobject.py
@@ -248,17 +248,16 @@ class CropObject(object):
     def __init__(self,
                  objid,  # type: int
                  clsname,  # type: str
-                 top,  # type: float
-                 left,  # type: float
-                 width,  # type: float
-                 height,  # type: float
+                 top,  # type: int
+                 left,  # type: int
+                 width,  # type: int
+                 height,  # type: int
                  outlinks=None,  # type: Optional[List[int]]
                  inlinks=None,  # type: Optional[List[int]]
                  mask=None,  # type: numpy.ndarray
                  uid=None,  # type: str
                  data=None
                  ):
-        # type: (...) -> None
         # logging.debug('Initializing CropObject with objid {0}, uid {5}, x={1},'
         #              ' y={2}, h={3}, w={4}'
         #               ''.format(objid, top, left, height, width, uid))
@@ -384,11 +383,13 @@ class CropObject(object):
 
     @staticmethod
     def build_uid(global_name, document_name, numid):
+        # type: (Any, Any, Any) -> str
         return CropObject.UID_DELIMITER.join([str(global_name),
                                               str(document_name),
                                               str(numid)])
 
     def set_uid(self, uid):
+        # type: (str) -> None
         """Assigns the given ``uid`` to the CropObject. This is the way
         to do it, do not assign directly to ``cropobject.uid``! You need
         to update other things (and perform integrity checks) when changing
@@ -411,12 +412,14 @@ class CropObject(object):
         self.set_uid(new_uid)
 
     def set_dataset(self, dataset_name):
+        # type: (str) -> None
         new_uid = self.UID_DELIMITER.join([dataset_name,
                                            self._document_namespace,
                                            str(self._instance)])
         self.set_uid(new_uid)
 
     def set_mask(self, mask):
+        # type: (numpy.ndarray) -> None
         """Sets the CropObject's mask to the given array. Performs
         some compatibilty checks: size, dtype (converts to ``uint8``)."""
         if mask is None:
@@ -438,6 +441,7 @@ class CropObject(object):
             self.mask = mask.astype('uint8')
 
     def set_objid(self, objid):
+        # type: (int) -> None
         """Changes the objid and updates the UID with it.
         Do NOT use this unless you know what you're doing;
         changing the objid should be (1) checked against objid
@@ -448,6 +452,7 @@ class CropObject(object):
         self._sync_objid_to_uid()
 
     def _sync_objid_to_uid(self):
+        # type: () -> None
         """Resets the UID number to reflect the objid."""
         g_name, doc_name, num = self._parse_uid(self.uid)
         new_uid = self.build_uid(g_name, doc_name, self.objid)
@@ -455,6 +460,7 @@ class CropObject(object):
 
     @property
     def dataset(self):
+        # type: () -> str
         """Which dataset is this CropObject coming from?
         For bookkeeping."""
         # The ``_dataset_namespace`` is set during initialization.
@@ -462,6 +468,7 @@ class CropObject(object):
 
     @property
     def doc(self):
+        # type: () -> str
         """Which document within the dataset is this CropObject
         coming from? The ``_document_namespace``
 
@@ -478,34 +485,40 @@ class CropObject(object):
 
     @property
     def top(self):
+        # type: () -> int
         """Row coordinate of upper left corner."""
         return self.x
 
     @property
     def bottom(self):
+        # type: () -> int
         """Row coordinate 1 beyond bottom right corner, so that indexing
         in the form ``img[c.top:c.bottom]`` is possible."""
         return self.x + self.height
 
     @property
     def left(self):
+        # type: () -> int
         """Column coordinate of upper left corner."""
         return self.y
 
     @property
     def right(self):
+        # type: () -> int
         """Column coordinate 1 beyond bottom right corner, so that indexing
         in the form ``img[:, c.left:c.right]`` is possible."""
         return self.y + self.width
 
     @property
     def bounding_box(self):
+        # type: () -> (int, int, int, int)
         """The ``top, left, bottom, right`` tuple of the CropObject's
         coordinates."""
         return self.top, self.left, self.bottom, self.right
 
     @property
     def middle(self):
+        # type: () -> (int, int)
         """Returns the integer representation of where the middle
         of the CropObject lies, as a ``(m_vert, m_horz)`` tuple.
 
@@ -517,6 +530,7 @@ class CropObject(object):
 
     @property
     def is_empty(self):
+        # type: () -> bool
         """A CropObject is empty if it is composed of zero pixels.
         This is measured through the mask. CropObjects without
         a mask are assumed to be non-empty."""
@@ -527,10 +541,12 @@ class CropObject(object):
 
     @property
     def outlink_uids(self):
+        # type: () -> List[str]
         return [self.build_uid(self.dataset, self.doc, o) for o in self.outlinks]
 
     @property
     def inlink_uids(self):
+        # type: () -> List[str]
         return [self.build_uid(self.dataset, self.doc, i) for i in self.inlinks]
 
     @staticmethod
@@ -572,6 +588,7 @@ class CropObject(object):
         return int(top), int(left), int(bottom), int(right)
 
     def to_integer_bounds(self):
+        # type: () -> None
         """Ensures that the CropObject has an integer position and size.
         (This is important whenever you want to use a mask, and reasonable
         whenever you do not need sub-pixel resolution...)
@@ -587,6 +604,7 @@ class CropObject(object):
         self.width = width
 
     def project_to(self, img):
+        # type: (numpy.ndarray) -> numpy.ndarray
         """This function returns the *crop* of the input image
         corresponding to the CropObject (incl. masking).
         Assumes zeros are background."""
@@ -598,6 +616,7 @@ class CropObject(object):
         return crop
 
     def project_on(self, img):
+        # type: (numpy.ndarray) -> numpy.ndarray
         """This function returns only those parts of the input image
         that correspond to the CropObject and masks out everything else
         with zeros. The dimension of the returned array is the same
@@ -632,7 +651,7 @@ class CropObject(object):
         return img
 
     def overlaps(self, bounding_box_or_cropobject):
-        # type: (Union[Tuple[float,float,float,float],CropObject]) -> bool
+        # type: (Union[Tuple[int,int,int,int],CropObject]) -> bool
         """Check whether this CropObject overlaps the given bounding box or CropObject.
 
         >>> c = CropObject(0, 'test', 10, 100, height=20, width=10)
@@ -692,6 +711,7 @@ class CropObject(object):
         return False
 
     def bbox_intersection(self, bounding_box):
+        # type: (Tuple[int,int, int, int]) -> Optional[Tuple[int,int, int, int]]
         """Returns the sub-bounding box of this CropObject, relative to its size (so: 0,0
         is the CropObject's upper left corner), that intersects the given bounding box.
         If the intersection is empty, returns None.
@@ -729,6 +749,7 @@ class CropObject(object):
             return None
 
     def crop_to_mask(self):
+        # type: () -> None
         """Crops itself to the minimum bounding box that contains all
         its pixels, as determined by its mask.
 
@@ -844,6 +865,7 @@ class CropObject(object):
         return '\n'.join(lines)
 
     def encode_mask(self, mask, compress=False, mode='rle'):
+        # type: (numpy.ndarray, bool, str) -> str
         """Encode a binary array ``mask`` as a string, compliant
         with the CropObject format specification in :mod:`muscima.io`.
         """
@@ -853,6 +875,7 @@ class CropObject(object):
             return self.encode_mask_bitmap(mask, compress=compress)
 
     def encode_data(self, data):
+        # type: () -> Optional[str]
         if self.data is None:
             return None
         if len(self.data) == 0:
@@ -896,6 +919,7 @@ class CropObject(object):
 
     @staticmethod
     def encode_mask_bitmap(mask, compress=False):
+        # type: (numpy.ndarray, bool) -> str
         """Encodes the mask array in a compact form. Returns 'None' if mask
         is None. If the mask is not None, uses the following algorithm:
 
@@ -915,6 +939,7 @@ class CropObject(object):
 
     @staticmethod
     def encode_mask_rle(mask, compress=False):
+        # type: (numpy.ndarray, bool) -> str
         """Encodes the mask array in Run-Length Encoding. Instead of
         having the bitmap ``0 0 1 1 1 0 0 0 1 1``, the RLE encodes
         the mask as ``0:2 1:3 0:3 1:2``. This is much more compact.
@@ -945,6 +970,7 @@ class CropObject(object):
         return output
 
     def decode_mask(self, mask_string, shape):
+        # type: (str, Tuple[Any, ...]) -> Optional[numpy.ndarray]
         """Decodes a CropObject mask string into a binary
         numpy array of the given shape."""
         mode = self._determine_mask_mode(mask_string)
@@ -954,6 +980,7 @@ class CropObject(object):
             return self.decode_mask_bitmap(mask_string, shape=shape)
 
     def _determine_mask_mode(self, mask_string):
+        # type: (str) -> str
         """If the mask string starts with '0:' or '1:', or generally
         if it contains a non-0 or 1 symbol, assume it is RLE."""
         mode = 'bitmap'
@@ -965,6 +992,7 @@ class CropObject(object):
 
     @staticmethod
     def decode_mask_bitmap(mask_string, shape):
+        # type: (str, Tuple[Any, ...]) -> Optional[numpy.ndarray]
         """Decodes the mask array from the encoded form to the 2D numpy array."""
         if mask_string == 'None':
             return None
@@ -981,6 +1009,7 @@ class CropObject(object):
 
     @staticmethod
     def decode_mask_rle(mask_string, shape):
+        # type: (str, Tuple[Any, ...]) -> Optional[numpy.ndarray]
         """Decodes the mask array from the RLE-encoded form
         to the 2D numpy array.
         """
@@ -998,6 +1027,7 @@ class CropObject(object):
         return mask
 
     def join(self, other):
+        # type: (CropObject) -> None
         """CropObject "addition": performs an OR on this
         and the ``other`` CropObjects' masks and bounding boxes,
         and assigns to this CropObject the result. Merges
@@ -1055,6 +1085,7 @@ class CropObject(object):
                 self.inlinks.append(i)
 
     def get_outlink_objects(self, cropobjects):
+        # type: (List[CropObject]) -> List[CropObject]
         """Out of the given ``cropobject`` list, return a list
         of those to which this CropObject has outlinks.
 
@@ -1076,6 +1107,7 @@ class CropObject(object):
         return output
 
     def get_inlink_objects(self, cropobjects):
+        # type: (List[CropObject]) -> List[CropObject]
         """Out of the given ``cropobject`` list, return a list
         of those from which this CropObject has inlinks.
 
@@ -1097,6 +1129,7 @@ class CropObject(object):
         return output
 
     def translate(self, down=0, right=0):
+        # type: (int, int) -> None
         """Move the cropobject down and right by the given amount of pixels."""
         self.x += down
         self.y += right
@@ -1105,6 +1138,7 @@ class CropObject(object):
 ##############################################################################
 # Functions for merging CropObjects and CropObjectLists
 def split_cropobject_on_connected_components(c, next_objid):
+    # type: (CropObject, int) -> List[CropObject]
     """Split the CropObject into one object per connected component
     of the mask. All inlinks/outlinks are retained in all the newly
     created CropObjects, and the old object is not changed. (If there
@@ -1158,6 +1192,7 @@ def split_cropobject_on_connected_components(c, next_objid):
 
 
 def cropobjects_merge(fr, to, clsname, objid):
+    # type: (CropObject, CropObject, str, int) -> CropObject
     """Merge the given CropObjects with respect to the other.
     Returns the new CropObject (without modifying any of the inputs)."""
     if fr.doc != to.doc:
@@ -1204,6 +1239,7 @@ def cropobjects_merge_multiple(cropobjects, clsname, objid):
 
 
 def cropobjects_merge_bbox(cropobjects):
+    # type: (List[CropObject]) -> (int, int, int, int)
     """Computes the bounding box of a CropObject that would
     result from merging the given list of CropObjects.
     """
@@ -1224,6 +1260,7 @@ def cropobjects_merge_bbox(cropobjects):
 
 
 def cropobjects_merge_mask(cropobjects, intersection=False):
+    # type: (List[CropObject], bool) -> Optional[numpy.ndarray]
     """Merges the given list of cropobjects into one. Masks are combined
     by an OR operation.
 
@@ -1286,6 +1323,7 @@ def cropobjects_merge_mask(cropobjects, intersection=False):
 
 
 def cropobjects_merge_links(cropobjects):
+    # type: (List[CropObject]) -> (List[CropObject], List[CropObject])
     """Collect all inlinks and outlinks of the given set of CropObjects
     to CropObjects outside of this set. The rationale for this is that
     these given ``cropobjects`` will be merged into one, so relationships
@@ -1310,6 +1348,7 @@ def cropobjects_merge_links(cropobjects):
 
 
 def merge_cropobject_lists(*cropobject_lists):
+    # type: (List[List[CropObject]]) -> List[CropObject]
     """Combines the CropObject lists from different documents
     into one list, so that inlink/outlink references still work.
     This is useful only if you want to merge two documents
@@ -1363,6 +1402,7 @@ def merge_cropobject_lists(*cropobject_lists):
 
 
 def link_cropobjects(fr, to, check_docname=True):
+    # type: (CropObject, CropObject, bool) -> None
     """Add a relationship from the ``fr`` CropObject
     to the ``to`` CropObject. Modifies the CropObjects
     in-place.
@@ -1391,6 +1431,7 @@ def link_cropobjects(fr, to, check_docname=True):
 
 
 def bbox_intersection(bbox_this, bbox_other):
+    # type: (Tuple[int, int, int, int],Tuple[int, int, int, int]) -> Optional[Tuple[int, int, int, int]]
     """Returns the t, l, b, r coordinates of the sub-bounding box
     of bbox_this that is also inside bbox_other.
     If the bounding boxes do not overlap, returns None."""
@@ -1413,6 +1454,7 @@ def bbox_intersection(bbox_this, bbox_other):
 
 
 def bbox_dice(bbox_this, bbox_other, vertical=False, horizontal=False):
+    # type: (Tuple[int, int, int, int], Tuple[int, int, int, int], bool, bool) -> float
     """Compute the Dice coefficient (intersection over union)
     for the given two bounding boxes.
 
@@ -1454,6 +1496,7 @@ def bbox_dice(bbox_this, bbox_other, vertical=False, horizontal=False):
 
 
 def cropobject_distance(c, d):
+    # type: (CropObject, CropObject) -> numpy.ndarray
     """Computes the distance between two CropObjects.
     Their minimum vertical and horizontal distances are each taken
     separately, and the euclidean norm is computed from them."""
@@ -1486,6 +1529,7 @@ def cropobject_distance(c, d):
 
 
 def cropobjects_on_canvas(cropobjects, margin=10):
+    # type: (List[CropObject], int) -> (numpy.ndarray, Tuple[int, int])
     """Draws all the given CropObjects onto a zero background.
     The size of the canvas adapts to the CropObjects, with the
     given margin.

--- a/muscima/cropobject_class.py
+++ b/muscima/cropobject_class.py
@@ -58,6 +58,7 @@ class CropObjectClass(object):
     out in the appropriate XML format.
     """
     def __init__(self, clsid, name, group_name, color):
+        # type: (int, str, str, str) -> None
         self.clsid = clsid
         self.name = name
         self.group_name = group_name

--- a/muscima/cropobject_class.py
+++ b/muscima/cropobject_class.py
@@ -41,6 +41,7 @@ for annotating MUSCIMA++.
 
 """
 import logging
+from typing import Tuple
 
 __version__ = "1.0"
 __author__ = "Jan Hajic jr."
@@ -88,6 +89,7 @@ _hex_itr = {v: k for k, v in _hex_tr.items()}
 
 
 def parse_hex(hstr):
+    # type: (str) -> int
     """Convert a hexadecimal number string to integer.
 
     >>> parse_hex('33')
@@ -103,6 +105,7 @@ def parse_hex(hstr):
 
 
 def hex2rgb(hstr):
+    # type: (str) -> Tuple[float, float, float]
     """Parse a hex-coded color like '#AA0202' into a floating-point representation.
 
     >>> hex2rgb('#abe822')
@@ -117,6 +120,7 @@ def hex2rgb(hstr):
 
 
 def rgb2hex(rgb):
+    # type: (Tuple[float, float, float]) -> str
     """Convert a floating-point representation of R, G, B values
     between 0 and 1 (inclusive) to a hex string (strating with a
     hashmark). Will use uppercase letters for 10 - 15.

--- a/muscima/dataset.py
+++ b/muscima/dataset.py
@@ -19,6 +19,7 @@ from __future__ import print_function, unicode_literals, division
 
 import logging
 import os
+from typing import Optional
 
 __version__ = "0.0.1"
 __author__ = "Jan Hajic jr."
@@ -28,6 +29,7 @@ __author__ = "Jan Hajic jr."
 
 
 def _get_cvc_muscima_root():
+    # type: () -> Optional[str]
     if 'CVC_MUSCIMA_ROOT' in os.environ:
         CVC_MUSCIMA_ROOT = os.environ['CVC_MUSCIMA_ROOT']
         return CVC_MUSCIMA_ROOT
@@ -35,12 +37,15 @@ def _get_cvc_muscima_root():
         logging.info('muscima.dataset: environmental variable CVC_MUSCIMA_ROOT not defined.')
         return None
 
+
 CVC_MUSCIMA_ROOT = _get_cvc_muscima_root()
+
 
 ##############################################################################
 
 
 def _get_mff_muscima_root():
+    # type: () -> Optional[str]
     if 'MUSCIMA_PLUSPLUS_ROOT' in os.environ:
         MUSCIMA_PLUSPLUS_ROOT = os.environ['MUSCIMA_PLUSPLUS_ROOT']
         return MUSCIMA_PLUSPLUS_ROOT
@@ -48,7 +53,9 @@ def _get_mff_muscima_root():
         logging.info('muscima.dataset: environmental variable MUSCIMA_PLUSPLUS_ROOT not defined.')
         return None
 
+
 MUSCIMA_PLUSPLUS_ROOT = _get_mff_muscima_root()
+
 
 ##############################################################################
 
@@ -81,6 +88,7 @@ class CVC_MUSCIMA:
     MODES = ['full', 'symbol', 'staff_only']
 
     def __init__(self, root=_get_cvc_muscima_root(), validate=False):
+        # type: (Optional[str], bool) -> None
         """The dataset is instantiated by providing the path to its root
         directory. If the ``CVC_MUSCIMA_ROOT`` variable is set, you do not
         have to provide anything."""
@@ -101,6 +109,7 @@ class CVC_MUSCIMA:
         self.root = root
 
     def imfile(self, page, writer, distortion='ideal', mode='full'):
+        # type: (int, int, str, str) -> str
         """Construct the path leading to the file of the CVC-MUSCIMA image
         with the specified page (1 - 20), writer (1 - 50), distortion
         (see ``CVC_MUSCIMA_DISTORTIONS``), and mode (``full``, ``symbol``,
@@ -129,6 +138,7 @@ class CVC_MUSCIMA:
         return fname
 
     def _number2page_file(self, n):
+        # type: (int) -> str
         if (n < 1) or (n > 20):
             raise ValueError('Invalid CVC-MUSCIMA score number {0}.'
                              ' Valid only between 1 and 20.'.format(n))
@@ -138,6 +148,7 @@ class CVC_MUSCIMA:
             return 'p0' + str(n) + '.png'
 
     def _number2writer_dir(self, n):
+        # type: (int) -> str
         if (n < 1) or (n > 50):
             raise ValueError('Invalid MUSCIMA writer number {0}.'
                              ' Valid only between 1 and 50.'.format(n))
@@ -147,6 +158,7 @@ class CVC_MUSCIMA:
             return 'w-' + str(n)
 
     def _mode2dir(self, mode):
+        # type: (str) -> str
         if mode == 'full':
             return 'image'
         elif mode == 'symbol':
@@ -155,6 +167,7 @@ class CVC_MUSCIMA:
             return 'gt'
 
     def validate(self, fail_early=True):
+        # type: (bool) -> bool
         """Checks whether the instantiated CVC_MUSCIMA instance really
         corresponds to the CVC-MUSCIMA dataset: all the 12 x 1000 expected
         CVC-MUSCIMA files should be present.

--- a/muscima/grammar.py
+++ b/muscima/grammar.py
@@ -31,6 +31,8 @@ import pprint
 
 import collections
 
+from typing import Union, Set, List
+
 __version__ = "0.0.1"
 __author__ = "Jan Hajic jr."
 
@@ -252,6 +254,7 @@ class DependencyGrammar(object):
     _MAX_CARD = 10000
 
     def __init__(self, grammar_filename, alphabet):
+        # type: (str, Union[Set[str], List[str]]) -> None
         """Initialize the Grammar: fill in alphabet and parse rules.
 
         :param grammar_filename: Path to a file that contains deprules

--- a/muscima/graph.py
+++ b/muscima/graph.py
@@ -7,6 +7,9 @@ import logging
 
 import operator
 
+from typing import Union, List, Optional, Dict, Tuple
+
+from muscima.cropobject import CropObject
 from muscima.cropobject import CropObject, cropobject_mask_rpf
 from muscima.inference_engine_constants import _CONST
 from muscima.utils import resolve_notehead_wrt_staffline
@@ -35,6 +38,7 @@ class NotationGraph(object):
         return len(self.cropobjects)
 
     def __to_objid(self, cropobject_or_objid):
+        # type: (Union[CropObject, int]) -> int
         if isinstance(cropobject_or_objid, CropObject):
             objid = cropobject_or_objid.objid
         else:
@@ -51,6 +55,7 @@ class NotationGraph(object):
         return edges
 
     def children(self, cropobject_or_objid, classes=None):
+        # type: (Union[CropObject, int], Optional[List[str]]) -> List[CropObject]
         """Find all children of the given node."""
         objid = self.__to_objid(cropobject_or_objid)
         if objid not in self._cdict:
@@ -67,6 +72,7 @@ class NotationGraph(object):
         return output
 
     def parents(self, cropobject_or_objid, classes=None):
+        # type: (Union[CropObject, int], Optional[List[str]]) -> List[CropObject]
         """Find all parents of the given node."""
         objid = self.__to_objid(cropobject_or_objid)
         if objid not in self._cdict:
@@ -83,6 +89,7 @@ class NotationGraph(object):
         return output
 
     def descendants(self, cropobject_or_objid, classes=None):
+        # type: (Union[CropObject, int], Optional[List[str]]) -> List[CropObject]
         """Find all descendants of the given node."""
         objid = self.__to_objid(cropobject_or_objid)
 
@@ -104,6 +111,7 @@ class NotationGraph(object):
         return [self._cdict[o] for o in descendant_objids]
 
     def ancestors(self, cropobject_or_objid, classes=None):
+        # type: (Union[CropObject, int], Optional[List[str]]) -> List[CropObject]
         """Find all ancestors of the given node."""
         objid = self.__to_objid(cropobject_or_objid)
 
@@ -125,14 +133,17 @@ class NotationGraph(object):
         return [self._cdict[objid] for objid in ancestor_objids]
 
     def has_child(self, cropobject_or_objid, classes=None):
+        # type: (Union[CropObject, int], Optional[List[str]]) -> bool
         children = self.children(cropobject_or_objid, classes=classes)
         return len(children) > 0
 
     def has_parent(self, cropobject_or_objid, classes=None):
+        # type: (Union[CropObject, int], Optional[List[str]]) -> bool
         parents = self.parents(cropobject_or_objid, classes=classes)
         return len(parents) > 0
 
     def is_child_of(self, cropobject_or_objid, other_cropobject_or_objid):
+        # type: (Union[CropObject, int], Union[CropObject,int]) -> bool
         """Check whether the first symbol is a child of the second symbol."""
         to_objid = self.__to_objid(cropobject_or_objid)
         from_objid = self.__to_objid(other_cropobject_or_objid)
@@ -144,6 +155,7 @@ class NotationGraph(object):
             return False
 
     def is_parent_of(self, cropobject_or_objid, other_cropobject_or_objid):
+        # type: (Union[CropObject, int], Union[CropObject,int]) -> bool
         """Check whether the first symbol is a parent of the second symbol."""
         from_objid = self.__to_objid(cropobject_or_objid)
         to_objid = self.__to_objid(other_cropobject_or_objid)
@@ -155,10 +167,12 @@ class NotationGraph(object):
             return False
 
     def __getitem__(self, objid):
+        # type: (int) -> CropObject
         """Returns a CropObject based on its objid."""
         return self._cdict[objid]
 
     def is_stem_direction_above(self, notehead, stem):
+        # type: (CropObject, CropObject) -> bool
         """Determines whether the given stem of the given notehead
         is above it or below. This is not trivial due to chords.
         """
@@ -182,6 +196,7 @@ class NotationGraph(object):
         return d_top > d_bottom
 
     def is_symbol_above_notehead(self, notehead, other, compare_on_intersect=False):
+        # type: (CropObject, CropObject, bool) -> bool
         """Determines whether the given other symbol is above
         the given notehead.
 
@@ -213,9 +228,9 @@ class NotationGraph(object):
         # Get vertical bounds of beam submask
         other_submask_hsum = beam_submask.sum(axis=1)
         other_submask_top = min([i for i in range(beam_submask.shape[0])
-                                if other_submask_hsum[i] != 0]) + other.top
+                                 if other_submask_hsum[i] != 0]) + other.top
         other_submask_bottom = max([i for i in range(beam_submask.shape[0])
-                                   if other_submask_hsum[i] != 0]) + other.top
+                                    if other_submask_hsum[i] != 0]) + other.top
         if (notehead.top <= other_submask_top <= notehead.bottom) \
                 or (other_submask_bottom <= notehead.top <= other_submask_bottom):
             if compare_on_intersect:
@@ -350,6 +365,7 @@ class NotationGraph(object):
 def group_staffs_into_systems(cropobjects,
                               use_fallback_measure_separators=True,
                               leftmost_measure_separators_only=False):
+    # type: (List[CropObject], bool, bool) -> List[List[CropObject]]
     """Returns a list of lists of ``staff`` CropObjects
     grouped into systems. Uses the outer ``staff_grouping``
     symbols (or ``measure_separator``) symbols.
@@ -452,6 +468,7 @@ def group_staffs_into_systems(cropobjects,
 
 
 def group_by_staff(cropobjects):
+    # type: (List[CropObject]) -> Dict[int, List[CropObject]]
     """Returns one NotationGraph instance for each staff and its associated
     CropObjects. "Associated" means:
 
@@ -487,6 +504,7 @@ def group_by_staff(cropobjects):
 
 def find_related_staffs(query_cropobjects, all_cropobjects,
                         with_stafflines=True):
+    # type: (List[CropObject], List[CropObject], bool) -> List[CropObject]
     """Find all staffs that are related to any of the cropobjects
     in question. Ignores whether these staffs are already within
     the list of ``query_cropobjects`` passed to the function.
@@ -517,7 +535,7 @@ def find_related_staffs(query_cropobjects, all_cropobjects,
     related_staffs = set()
     for c in query_cropobjects:
         desc_staffs = graph.descendants(c, classes=[_CONST.STAFF_CLSNAME])
-        anc_staffs =  graph.ancestors(c, classes=[_CONST.STAFF_CLSNAME])
+        anc_staffs = graph.ancestors(c, classes=[_CONST.STAFF_CLSNAME])
         current_staffs = set(desc_staffs + anc_staffs)
         related_staffs = related_staffs.union(current_staffs)
 
@@ -540,6 +558,7 @@ def find_related_staffs(query_cropobjects, all_cropobjects,
 
 
 def find_beams_incoherent_with_stems(cropobjects):
+    # type: (List[CropObject]) -> List[Tuple[CropObject,CropObject]]
     """Searches the graph for edges where a notehead is connected to a stem
     in one direction, but is connected to beams that are in the
     other direction.
@@ -590,6 +609,7 @@ def find_beams_incoherent_with_stems(cropobjects):
 # *AND* a ledger line.
 
 def find_ledger_lines_with_noteheads_from_both_directions(cropobjects):
+    # type: (List[CropObject]) -> List[CropObject]
     """Looks for ledger lines that have inlinks from noteheads
     on both sides. Returns a list of ledger line CropObjects."""
     graph = NotationGraph(cropobjects)
@@ -615,6 +635,7 @@ def find_ledger_lines_with_noteheads_from_both_directions(cropobjects):
 
 
 def find_noteheads_with_ledger_line_and_staff_conflict(cropobjects):
+    # type: (List[CropObject]) -> List[CropObject]
     """Find all noteheads that have a relationship both to a staffline
     or staffspace and to a ledger line.
 
@@ -639,6 +660,7 @@ def find_noteheads_with_ledger_line_and_staff_conflict(cropobjects):
 
 
 def find_noteheads_on_staff_linked_to_ledger_line(cropobjects):
+    # type: (List[CropObject]) -> List[Tuple[CropObject, CropObject]]
     """Find all noteheads that are linked to a ledger line,
     but at the same time intersect a staffline or lie
     entirely within a staffspace. These should be fixed
@@ -707,8 +729,8 @@ def find_misdirected_ledger_line_edges(cropobjects,
 
         staffs = graph.children(c, ['staff'])
         if not staffs:
-            logging.warn('Notehead {0} not connected to any staff!'
-                         ''.format(c.uid))
+            logging.warning('Notehead {0} not connected to any staff!'
+                            ''.format(c.uid))
             continue
         staff = staffs[0]
 
@@ -749,6 +771,7 @@ def find_misdirected_ledger_line_edges(cropobjects,
 
 
 def resolve_ledger_line_or_staffline_object(cropobjects):
+    # type: (List[CropObject]) -> None
     """If staff relationships are created before notehead to ledger line
     relationships, then there will be noteheads on ledger lines that
     are nevertheless connected to staffspaces. This function should be
@@ -777,15 +800,15 @@ def resolve_ledger_line_or_staffline_object(cropobjects):
             continue
 
         if len(staff) == 0:
-            logging.warn('Notehead {0} not connected to any staff!'
-                         ' Unable to resolve ll/staffline.'.format(c.uid))
+            logging.warning('Notehead {0} not connected to any staff!'
+                            ' Unable to resolve ll/staffline.'.format(c.uid))
             continue
 
         # Multiple LLs: must check direction
         # Multiple stafflines: ???
         if len(stafflines) > 1:
-            logging.warn('Notehead {0} is connected to multiple staffline'
-                         ' objects!'.format(c.uid))
+            logging.warning('Notehead {0} is connected to multiple staffline'
+                            ' objects!'.format(c.uid))
 
 
 ##############################################################################

--- a/muscima/inference.py
+++ b/muscima/inference.py
@@ -382,12 +382,8 @@ class PitchInferenceEngine(object):
     * Staff groupings are correct, and systems are read top-down.
 
     """
-<<<<<<< HEAD
-    def __init__(self, strategy=PitchInferenceStrategy()):
-=======
 
-    def __init__(self):
->>>>>>> Auto-formatted inference.py
+    def __init__(self, strategy=PitchInferenceStrategy()):
         # Inference engine constants
         self._CONST = InferenceEngineConstants()
 

--- a/muscima/inference.py
+++ b/muscima/inference.py
@@ -83,6 +83,7 @@ class PitchInferenceEngineState(object):
     Iterate through the relevant objects on a staff, sorted left-to-right
     by left edge.
     """
+
     def __init__(self):
 
         self.base_pitch = None
@@ -285,7 +286,7 @@ class PitchInferenceEngineState(object):
 
         # From the base pitch and clef:
         step_pitch = self.base_pitch \
-                     + sum(self._current_delta_steps[:delta_step+1]) \
+                     + sum(self._current_delta_steps[:delta_step + 1]) \
                      + (delta_octave * 12)
         accidental_pitch = self.accidental(delta)
 
@@ -369,7 +370,12 @@ class PitchInferenceEngine(object):
     * Staff groupings are correct, and systems are read top-down.
 
     """
+<<<<<<< HEAD
     def __init__(self, strategy=PitchInferenceStrategy()):
+=======
+
+    def __init__(self):
+>>>>>>> Auto-formatted inference.py
         # Inference engine constants
         self._CONST = InferenceEngineConstants()
 
@@ -496,11 +502,11 @@ class PitchInferenceEngine(object):
         self.pitch_state.init_base_pitch()
 
         queue = sorted(
-                    self.staff_to_clef_map[staff.objid]
-                    + self.staff_to_key_map[staff.objid]
-                    + self.staff_to_msep_map[staff.objid]
-                    + self.staff_to_noteheads_map[staff.objid],
-                    key=lambda x: x.left)
+            self.staff_to_clef_map[staff.objid]
+            + self.staff_to_key_map[staff.objid]
+            + self.staff_to_msep_map[staff.objid]
+            + self.staff_to_noteheads_map[staff.objid],
+            key=lambda x: x.left)
 
         for q in queue:
             logging.info('process_staff(): processing object {0}-{1}'
@@ -662,7 +668,7 @@ class PitchInferenceEngine(object):
             #    then it would be weird to find out it is in the
             #    mini-staffspace *below* the closest ledger line,
             #    signalling a mistake in the data.
-            closest_ll = min(lls, key=lambda x: (x.top - notehead.top)**2 + (x.bottom - notehead.bottom)**2)
+            closest_ll = min(lls, key=lambda x: (x.top - notehead.top) ** 2 + (x.bottom - notehead.bottom) ** 2)
 
             # Determining whether the notehead is on a ledger
             # line or in the adjacent temp staffspace.
@@ -855,7 +861,7 @@ class PitchInferenceEngine(object):
 
         # Collect measure separators.
         self.measure_separators = [c for c in cropobjects
-                              if c.clsname == 'measure_separator']
+                                   if c.clsname == 'measure_separator']
         if ignore_nonstaff:
             self.measure_separators = [c for c in self.measure_separators
                                        if graph.has_child(c, ['staff'])]
@@ -997,7 +1003,7 @@ class OnsetsInferenceEngine(object):
             if len(stems) == 0:
                 self.__warning_or_error('Full notehead {0} has no stem!'.format(notehead.uid))
 
-            beat = [0.5**len(flags_and_beams)]
+            beat = [0.5 ** len(flags_and_beams)]
 
         else:
             raise ValueError('Notehead {0}: unknown clsname {1}'
@@ -1096,7 +1102,7 @@ class OnsetsInferenceEngine(object):
             for whole rests.
 
         """
-        rest_beats_dict = {'whole_rest': 4,   # !!! We should find the Time Signature.
+        rest_beats_dict = {'whole_rest': 4,  # !!! We should find the Time Signature.
                            'half_rest': 2,
                            'quarter_rest': 1,
                            '8th_rest': 0.5,
@@ -1224,8 +1230,8 @@ class OnsetsInferenceEngine(object):
                 f_and_b_below.append(c)
                 print('Appending below')
 
-        beat_above = 0.5**len(f_and_b_above)
-        beat_below = 0.5**len(f_and_b_below)
+        beat_above = 0.5 ** len(f_and_b_above)
+        beat_below = 0.5 ** len(f_and_b_below)
 
         if beat_above != beat_below:
             raise NotImplementedError('Cannot deal with multi-stem note'
@@ -1615,7 +1621,7 @@ class OnsetsInferenceEngine(object):
 
         # Create measure bins. i-th measure ENDS at i-th ordered msep.
         # We assume that every measure has a rightward separator.
-        measures = [(None, ordered_mseps[0])] + [(ordered_mseps[i], ordered_mseps[i+1])
+        measures = [(None, ordered_mseps[0])] + [(ordered_mseps[i], ordered_mseps[i + 1])
                                                  for i in range(len(ordered_mseps) - 1)]
         measure_nodes = [PrecedenceGraphNode(objid=None,
                                              cropobject=None,
@@ -1625,8 +1631,8 @@ class OnsetsInferenceEngine(object):
                                              onset=None)] + \
                         [PrecedenceGraphNode(objid=None,
                                              cropobject=None,
-                                             inlinks=[ordered_msep_nodes[i+1]],
-                                             outlinks=[ordered_msep_nodes[i+2]],
+                                             inlinks=[ordered_msep_nodes[i + 1]],
+                                             outlinks=[ordered_msep_nodes[i + 2]],
                                              duration=0,  # Durations will be filled in
                                              onset=None)
                          for i in range(len(ordered_msep_nodes) - 2)]
@@ -1773,7 +1779,7 @@ class OnsetsInferenceEngine(object):
                 msep_to_staff_projections[msep.objid][s.objid] = intersection_bbox
 
         staff_and_measure_to_objs_map = collections.defaultdict(
-                                            collections.defaultdict(list))
+            collections.defaultdict(list))
         #: Per staff (indexed by objid) and measure (by order no.), keeps a list of
         #  CropObjects from that staff that fall within that measure.
 
@@ -1784,7 +1790,7 @@ class OnsetsInferenceEngine(object):
         for s_objid, objs in ordered_objs_per_staff.items():
             # Vertically, we don't care -- the attachment to staff takes
             # care of that, we only need horizontal placement.
-            _c_m_idx = 0   # Index of current measure
+            _c_m_idx = 0  # Index of current measure
             _c_msep_right = measure_nodes[_c_m_idx].outlinks[0]
             # Left bound of current measure's right measure separator
             _c_m_right = msep_to_staff_projections[_c_msep_right.objid][s_objid][1]
@@ -2273,6 +2279,7 @@ class PrecedenceGraphNode:
     The ``inlinks`` and ``outlinks`` attributes are lists
     of other ``PrecedenceGraphNode`` instances.
     """
+
     def __init__(self, objid=None, cropobject=None, inlinks=None, outlinks=None,
                  onset=None, duration=0):
         # Optional link to CropObjects, or just a placeholder ID.
@@ -2386,10 +2393,10 @@ class MIDIBuilder:
         from midiutil.MidiFile import MIDIFile
 
         # create your MIDI object
-        mf = MIDIFile(1)     # only 1 track
-        track = 0   # the only track
+        mf = MIDIFile(1)  # only 1 track
+        track = 0  # the only track
 
-        time = 0    # start at the beginning
+        time = 0  # start at the beginning
         mf.addTrackName(track, time, "Sample Track")
         mf.addTempo(track, time, tempo)
 
@@ -2441,6 +2448,7 @@ def play_midi(midi,
     fs.play_midi(tmp_midi_path)
     # Here's hoping it's a blocking call. Otherwise, just leave the MIDI;
     # MUSCIMarker cleans its tmp dir whenever it exits.
+<<<<<<< HEAD
     if cleanup:
         os.unlink(tmp_midi_path)
 
@@ -2481,3 +2489,6 @@ def align_mung_with_midi(cropobjects, midi_file):
     # Alignment algorithm:
     # - find in MIDI events list the closest corresponding
     #   object for each notehead.
+=======
+    os.unlink(tmp_midi_path)
+>>>>>>> Auto-formatted inference.py

--- a/muscima/inference_engine_constants.py
+++ b/muscima/inference_engine_constants.py
@@ -4,6 +4,8 @@ from __future__ import print_function, unicode_literals, division
 
 import operator
 
+from typing import List, Set
+
 __version__ = "0.0.1"
 __author__ = "Jan Hajic jr."
 
@@ -12,11 +14,11 @@ class InferenceEngineConstants(object):
     """This class stores the constants used for pitch inference."""
 
     ON_STAFFLINE_RATIO_TRHESHOLD = 0.2
-    '''Magic number for determining whether a notehead is *on* a ledger
+    """Magic number for determining whether a notehead is *on* a ledger
     line, or *next* to a ledger line: if the ratio between the smaller
     and larger vertical difference of (top, bottom) vs. l.l. (top, bottom)
     is smaller than this, it means the notehead is most probably *NOT*
-    on the l.l. and is next to it.'''
+    on the l.l. and is next to it."""
 
     STAFFLINE_CLSNAME = 'staff_line'
     STAFFSPACE_CLSNAME = 'staff_space'
@@ -80,7 +82,7 @@ class InferenceEngineConstants(object):
         'beam',
     }
 
-    FLAGS_AND_BEAMS ={
+    FLAGS_AND_BEAMS = {
         '8th_flag',
         '16th_flag',
         '32th_flag',
@@ -110,7 +112,7 @@ class InferenceEngineConstants(object):
         10: 'Bb',
         11: 'B',
     }
-    '''Simplified pitch naming.'''
+    """Simplified pitch naming."""
 
     # The individual MIDI codes for for the unmodified steps.
     _fs = list(range(5, 114, 12))
@@ -221,6 +223,7 @@ class InferenceEngineConstants(object):
 
     @property
     def clsnames_affecting_onsets(self):
+        # type: () -> Set[str]
         """Returns a list of CropObject class names for objects
         that affect onsets. Assumes notehead and rest durations
         have already been given."""
@@ -234,6 +237,7 @@ class InferenceEngineConstants(object):
 
     @property
     def clsnames_bearing_duration(self):
+        # type: () -> Set[str]
         """Returns the list of classes that actually bear duration,
         i.e. contribute to onsets of their descendants in the precedence
         graph."""
@@ -244,8 +248,10 @@ class InferenceEngineConstants(object):
 
     @staticmethod
     def interpret_numerals(numerals):
+        from muscima.cropobject import CropObject
+        # type: (List[CropObject]) -> int
         """Returns the given numeral CropObject as a number, left to right."""
-        for n in numerals:
+        for n in numerals:  # type: CropObject
             if n.clsname not in InferenceEngineConstants.NUMERALS:
                 raise ValueError('Symbol {0} is not a numeral!'.format(n.uid))
         n_str = ''.join([n.clsname[-1]

--- a/muscima/io.py
+++ b/muscima/io.py
@@ -255,6 +255,8 @@ import logging
 import os
 
 import collections
+from typing import List
+
 from lxml import etree
 
 from muscima.cropobject import CropObject
@@ -268,6 +270,7 @@ __author__ = "Jan Hajic jr."
 
 
 def parse_cropobject_list(filename):
+    # type: (str) -> List[CropObject]
     """From a xml file with a CropObjectList as the top element, parse
     a list of CropObjects. (See ``CropObject`` class documentation
     for a description of the XMl format.)
@@ -410,7 +413,6 @@ def parse_cropobject_list(filename):
             if o_s_text is not None:
                 outlinks = list(map(int, o_s_text.split(' ')))
 
-
         #################################
         # Decode the data.
         data = cropobject.findall('Data')
@@ -423,7 +425,7 @@ def parse_cropobject_list(filename):
                 value_type = data_item.get('type')
                 value = data_item.text
 
-                #logging.debug('Creating data entry: key={0}, type={1},'
+                # logging.debug('Creating data entry: key={0}, type={1},'
                 #              ' value={2}'.format(key, value_type, value))
 
                 if value_type == 'int':

--- a/muscima/io.py
+++ b/muscima/io.py
@@ -255,7 +255,7 @@ import logging
 import os
 
 import collections
-from typing import List
+from typing import List, Tuple, Optional
 
 from lxml import etree
 
@@ -483,6 +483,7 @@ def parse_cropobject_list(filename):
 
 
 def validate_cropobjects_graph_structure(cropobjects):
+    # type: (List[CropObject]) -> bool
     """Check that the graph defined by the ``inlinks`` and ``outlinks``
     in the given list of CropObjects is valid: no relationships
     leading from or to objects with non-existent ``objid``s.
@@ -511,6 +512,7 @@ def validate_cropobjects_graph_structure(cropobjects):
 
 
 def validate_document_graph_structure(cropobjects):
+    # type: (List[CropObject]) -> bool
     """Check that the graph defined by the ``inlinks`` and ``outlinks``
     in the given list of CropObjects is valid: no relationships
     leading from or to objects with non-existent ``objid``s.
@@ -549,6 +551,7 @@ def validate_document_graph_structure(cropobjects):
 
 
 def export_cropobject_graph(cropobjects, validate=True):
+    # type: (List[CropObject], bool) -> List[Tuple[int, int]]
     """Collects the inlink/outlink CropObject graph
     and returns it as a list of ``(from, to)`` edges.
 
@@ -573,6 +576,7 @@ def export_cropobject_graph(cropobjects, validate=True):
 
 
 def export_cropobject_list(cropobjects, docname=None, dataset_name=None):
+    # type: (List[CropObject], Optional[str], Optional[str]) -> str
     """Writes the CropObject data as a XML string. Does not write
     to a file -- use ``with open(output_file) as out_stream:`` etc.
 

--- a/muscima/io.py
+++ b/muscima/io.py
@@ -629,6 +629,7 @@ def export_cropobject_list(cropobjects, docname=None, dataset_name=None):
 # Parsing CropObjectClass lists, mostly for grammars.
 
 def parse_cropobject_class_list(filename):
+    # type: (str) -> List[CropObjectClass]
     """From a xml file with a MLClassList as the top element,
     extract the list of :class:`CropObjectClass` objects. Use
     this
@@ -646,12 +647,12 @@ def parse_cropobject_class_list(filename):
 
 
 def export_cropobject_class_list(cropobject_classes):
+    # type: (List[CropObjectClass]) -> str
     """Writes the CropObject data as a XML string. Does not write
     to a file -- use ``with open(output_file) as out_stream:`` etc.
 
-    :param cropobjects: A list of CropObject instances.
+    :param cropobject_classes: A list of CropObjectClass instances.
     """
-    # This is the data string, the rest is formalities
     cropobject_classes_string = '\n'.join([str(c) for c in cropobject_classes])
 
     lines = list()

--- a/muscima/stafflines.py
+++ b/muscima/stafflines.py
@@ -11,7 +11,7 @@ import pprint
 import numpy
 from skimage.filters import gaussian
 from skimage.morphology import watershed
-from typing import List
+from typing import List, Tuple
 
 from muscima.cropobject import CropObject, cropobjects_on_canvas, link_cropobjects
 from muscima.graph import NotationGraph, find_noteheads_on_staff_linked_to_ledger_line
@@ -138,6 +138,7 @@ def merge_staffline_segments(cropobjects, margin=10):
 
 
 def staffline_bboxes_and_masks_from_horizontal_merge(mask):
+    # type: (numpy.ndarray) -> (List[Tuple[int,int,int,int]],List[numpy.ndarray])
     """Returns a list of staff_line bboxes and masks
      computed from the input mask, with
     each set of connected components in the mask that has at least
@@ -234,7 +235,9 @@ def staffline_bboxes_and_masks_from_horizontal_merge(mask):
     return staffline_bboxes, staffline_masks
 
 
-def staff_bboxes_and_masks_from_staffline_bboxes_and_image(staffline_bboxes, mask):
+def staff_bboxes_and_masks_from_staffline_bboxes_and_image(staffline_bboxes, image):
+    # type: (List[Tuple[int,int,int,int]],numpy.ndarray) -> (List[Tuple[int,int,int,int]], List[numpy.ndarray])
+
     logging.warning('Creating staff bboxes and masks.')
 
     #  - Go top-down and group the stafflines by five to get staves.
@@ -250,7 +253,7 @@ def staff_bboxes_and_masks_from_staffline_bboxes_and_image(staffline_bboxes, mas
         _sb = max([bb[2] for bb in _sbb])
         _sr = max([bb[3] for bb in _sbb])
         staff_bboxes.append((_st, _sl, _sb, _sr))
-        staff_masks.append(mask[_st:_sb, _sl:_sr])
+        staff_masks.append(image[_st:_sb, _sl:_sr])
 
     logging.warning('Total staffs: {0}'.format(len(staff_bboxes)))
 
@@ -258,6 +261,7 @@ def staff_bboxes_and_masks_from_staffline_bboxes_and_image(staffline_bboxes, mas
 
 
 def staffline_surroundings_mask(staffline_cropobject):
+    # type: (CropObject) -> (numpy.ndarray, numpy.ndarray)
     """Find the parts of the staffline's bounding box which lie
     above or below the actual staffline.
 
@@ -288,7 +292,8 @@ def staffline_surroundings_mask(staffline_cropobject):
 
 
 def build_staff_cropobjects(cropobjects):
-    """Derives staff objects from staffline objcets.
+    # type: (List[CropObject]) -> List[CropObject]
+    """Derives staff objects from staffline objects.
 
     Assumes each staff has 5 stafflines.
 
@@ -347,6 +352,7 @@ def build_staff_cropobjects(cropobjects):
 
 
 def build_staffspace_cropobjects(cropobjects):
+    # type: (List[CropObject]) -> List[CropObject]
     """Creates the staffspace objects based on stafflines
     and staffs. There is a staffspace between each two stafflines,
     one on the top side of each staff, and one on the bottom
@@ -539,6 +545,7 @@ def build_staffspace_cropobjects(cropobjects):
 def add_staff_relationships(cropobjects,
                             notehead_staffspace_threshold=0.2,
                             reprocess_noteheads_inside_staff_with_lls=True):
+    # type: (List[CropObject], float, bool) -> List[CropObject]
     """Adds the relationships from various symbols to staff objects:
     stafflines, staffspaces, and staffs.
 

--- a/muscima/stafflines.py
+++ b/muscima/stafflines.py
@@ -17,7 +17,6 @@ from muscima.graph import NotationGraph, find_noteheads_on_staff_linked_to_ledge
 from muscima.inference_engine_constants import InferenceEngineConstants as _CONST
 from muscima.utils import compute_connected_components
 
-
 __version__ = "0.0.1"
 __author__ = "Jan Hajic jr."
 
@@ -75,7 +74,7 @@ def merge_staffline_segments(cropobjects, margin=10):
     """
     already_processed_stafflines = [c for c in cropobjects
                                     if (c.clsname == _CONST.STAFFLINE_CLSNAME) and
-                                        __has_parent_staff(c, cropobjects)]
+                                    __has_parent_staff(c, cropobjects)]
     # margin is used to avoid the stafflines touching the edges,
     # which could perhaps break some assumptions down the line.
     old_staffline_cropobjects = [c for c in cropobjects
@@ -240,7 +239,7 @@ def staff_bboxes_and_masks_from_staffline_bboxes_and_image(staffline_bboxes, mas
 
     n_stafflines = len(staffline_bboxes)
     for i in range(n_stafflines // 5):
-        _sbb = staffline_bboxes[5*i:5*(i+1)]
+        _sbb = staffline_bboxes[5 * i:5 * (i + 1)]
         _st = min([bb[0] for bb in _sbb])
         _sl = min([bb[1] for bb in _sbb])
         _sb = max([bb[2] for bb in _sbb])
@@ -291,7 +290,7 @@ def build_staff_cropobjects(cropobjects):
     Assumes the stafflines have already been merged."""
     stafflines = [c for c in cropobjects
                   if c.clsname == _CONST.STAFFLINE_CLSNAME and
-                    not __has_parent_staff(c, cropobjects)]
+                  not __has_parent_staff(c, cropobjects)]
     if len(stafflines) == 0:
         return []
 
@@ -307,13 +306,13 @@ def build_staff_cropobjects(cropobjects):
 
     n_stafflines = len(stafflines)
     for i in range(n_stafflines // 5):
-        _sbb = staffline_bboxes[5*i:5*(i+1)]
+        _sbb = staffline_bboxes[5 * i:5 * (i + 1)]
         _st = min([bb[0] for bb in _sbb])
         _sl = min([bb[1] for bb in _sbb])
         _sb = max([bb[2] for bb in _sbb])
         _sr = max([bb[3] for bb in _sbb])
         staff_bboxes.append((_st, _sl, _sb, _sr))
-        staff_masks.append(canvas[_st-_t:_sb-_t, _sl-_l:_sr-_l])
+        staff_masks.append(canvas[_st - _t:_sb - _t, _sl - _l:_sr - _l])
 
     logging.info('Creating staff CropObjects')
     next_objid = max([c.objid for c in cropobjects]) + 1
@@ -415,8 +414,8 @@ def build_staffspace_cropobjects(cropobjects):
             logging.debug(canvas.shape)
             logging.debug('l={0}, dl1={1}, dl2={2}, r={3}, dr1={4}, dr2={5}'
                           ''.format(l, dl1, dl2, r, dr1, dr2))
-            #canvas[:s1.height, :] += s1.mask[:, dl1:s1.width-dr1]
-            #canvas[-s2.height:, :] += s2.mask[:, dl2:s2.width-dr2]
+            # canvas[:s1.height, :] += s1.mask[:, dl1:s1.width-dr1]
+            # canvas[-s2.height:, :] += s2.mask[:, dl2:s2.width-dr2]
 
             # We have to deal with staffline interruptions.
             # One way to do this
@@ -441,8 +440,8 @@ def build_staffspace_cropobjects(cropobjects):
             # We now take the intersection of s1_below and s2_above.
             # If there is empty space in the middle, we fill it in.
             staffspace_mask = numpy.ones(canvas.shape)
-            staffspace_mask[s1_t:s1_b, :] -= (1 - s1_below[:, dl1:s1.width-dr1])
-            staffspace_mask[s2_t:s2_b, :] -= (1 - s2_above[:, dl2:s2.width-dr2])
+            staffspace_mask[s1_t:s1_b, :] -= (1 - s1_below[:, dl1:s1.width - dr1])
+            staffspace_mask[s2_t:s2_b, :] -= (1 - s2_above[:, dl2:s2.width - dr2])
 
             ss_top = s1.top
             ss_bottom = s2.bottom
@@ -506,7 +505,7 @@ def build_staffspace_cropobjects(cropobjects):
         bsl = sorted_stafflines[-1]
         bsl_heights = bsl.mask.sum(axis=0)
 
-        lss_top = bss.bottom # + max(bsl_heights)
+        lss_top = bss.bottom  # + max(bsl_heights)
         lss_left = bss.left
         lss_width = bss.width
         lss_height = int(bss.height / 1.2)
@@ -641,7 +640,7 @@ def add_staff_relationships(cropobjects,
     stafflines = [c for c in cropobjects if c.clsname == _CONST.STAFFLINE_CLSNAME]
     stafflines = sorted(stafflines, key=lambda c: c.top)
     staffspaces = [c for c in cropobjects if c.clsname == _CONST.STAFFSPACE_CLSNAME]
-    staffspaces= sorted(staffspaces, key=lambda c: c.top)
+    staffspaces = sorted(staffspaces, key=lambda c: c.top)
     staves = [c for c in cropobjects if c.clsname == _CONST.STAFF_CLSNAME]
     staves = sorted(staves, key=lambda c: c.top)
 
@@ -732,7 +731,7 @@ def add_staff_relationships(cropobjects,
                                      key=lambda ss: min((ll_max_dist.bottom - ss.top) ** 2,
                                                         (ll_max_dist.top - ss.bottom) ** 2))
                 distance_of_closest_staff = (ll_max_dist.top + ll_max_dist.bottom) / 2 \
-                                    - (staff_min_dist.top + staff_min_dist.bottom) / 2
+                                            - (staff_min_dist.top + staff_min_dist.bottom) / 2
                 if numpy.abs(distance_of_closest_staff) > (50 + 0.5 * staff_min_dist.height):
                     logging.debug('Trying to join notehead with ledger line to staff,'
                                   ' but the distance is larger than 50. Notehead: {0},'
@@ -764,9 +763,9 @@ def add_staff_relationships(cropobjects,
 
             if c.objid < 10:
                 logging.info('Notehead {0} ({1}): overlaps {2} stafflines'.format(c.uid,
-                                                                                   c.bounding_box,
-                                                                                   len(overlapped_stafflines),
-                                                                                   ))
+                                                                                  c.bounding_box,
+                                                                                  len(overlapped_stafflines),
+                                                                                  ))
 
             if len(overlapped_stafflines) == 1:
                 s = overlapped_stafflines[0]
@@ -871,4 +870,3 @@ def add_staff_relationships(cropobjects,
 
     ##########################################################################
     return cropobjects
-

--- a/muscima/stafflines.py
+++ b/muscima/stafflines.py
@@ -11,6 +11,7 @@ import pprint
 import numpy
 from skimage.filters import gaussian
 from skimage.morphology import watershed
+from typing import List
 
 from muscima.cropobject import CropObject, cropobjects_on_canvas, link_cropobjects
 from muscima.graph import NotationGraph, find_noteheads_on_staff_linked_to_ledger_line
@@ -25,6 +26,7 @@ __author__ = "Jan Hajic jr."
 
 
 def __has_parent_staff(c, cropobjects):
+    # type: (CropObject, List[CropObject]) -> bool
     _cdict = {c.objid: c for c in cropobjects}
     staff_inlinks = [_cdict[i] for i in c.inlinks
                      if _cdict[i].clsname == _CONST.STAFF_CLSNAME]
@@ -32,6 +34,7 @@ def __has_parent_staff(c, cropobjects):
 
 
 def __has_child_staffspace(staff, cropobjects):
+    # type: (CropObject, List[CropObject]) -> bool
     _cdict = {c.objid: c for c in cropobjects}
     staffline_outlinks = [_cdict[i] for i in staff.outlinks
                           if _cdict[i].clsname == _CONST.STAFFSPACE_CLSNAME]
@@ -39,6 +42,7 @@ def __has_child_staffspace(staff, cropobjects):
 
 
 def __has_neighbor_staffspace(staffline, cropobjects):
+    # type: (CropObject, List[CropObject]) -> bool
     _cdict = {c.objid: c for c in cropobjects}
     # Find parent staff
     if not __has_parent_staff(staffline, cropobjects):
@@ -56,6 +60,7 @@ def __has_neighbor_staffspace(staffline, cropobjects):
 
 
 def merge_staffline_segments(cropobjects, margin=10):
+    # type: (List[CropObject], int) -> List[CropObject]
     """Given a list of CropObjects that contain some staffline
     objects, generates a new list where the stafflines
     are merged based on their horizontal projections.

--- a/muscima/utils.py
+++ b/muscima/utils.py
@@ -4,7 +4,6 @@ from __future__ import print_function, unicode_literals
 import logging
 
 import numpy
-from muscima.cropobject import CropObject
 from skimage.measure import label
 from typing import Dict, List, Tuple
 
@@ -67,6 +66,7 @@ def compute_connected_components(image):
 
 
 def resolve_notehead_wrt_staffline(notehead, staffline_or_ledger_line):
+    from muscima.cropobject import CropObject
     # type: (CropObject, CropObject) -> int
     """Resolves the relative vertical position of the notehead with respect
     to the given staff_line or ledger_line object. Returns -1 if notehead
@@ -136,6 +136,7 @@ def resolve_notehead_wrt_staffline(notehead, staffline_or_ledger_line):
 
 
 def is_notehead_on_line(notehead, line_obj):
+    from muscima.cropobject import CropObject
     # type: (CropObject, CropObject) -> bool
     """Check whether given notehead is positioned on the line object."""
     if line_obj.clsname not in _CONST.STAFFLINE_LIKE_CROPOBJECT_CLSNAMES:

--- a/muscima/utils.py
+++ b/muscima/utils.py
@@ -3,7 +3,10 @@ from __future__ import print_function, unicode_literals
 
 import logging
 
+import numpy
+from muscima.cropobject import CropObject
 from skimage.measure import label
+from typing import Dict, List, Tuple
 
 from muscima.inference_engine_constants import InferenceEngineConstants as _CONST
 
@@ -15,6 +18,7 @@ __author__ = "Jan Hajic jr."
 
 
 def connected_components2bboxes(labels):
+    # type: (List[List[int]]) -> Dict[int,Tuple[int, int, int, int]]
     """Returns a dictionary of bounding boxes (upper left c., lower right c.)
     for each label.
 
@@ -37,10 +41,10 @@ def connected_components2bboxes(labels):
         lies exactly within labels[xmin:xmax, ymin:ymax].
     """
     bboxes = {}
-    for x, row in enumerate(labels):
-        for y, l in enumerate(row):
+    for x, row in enumerate(labels):  # type: int, List[int]
+        for y, l in enumerate(row):  # type: int, int
             if l not in bboxes:
-                bboxes[l] = [x, y, x+1, y+1]
+                bboxes[l] = [x, y, x + 1, y + 1]
             else:
                 box = bboxes[l]
                 if x < box[0]:
@@ -55,6 +59,7 @@ def connected_components2bboxes(labels):
 
 
 def compute_connected_components(image):
+    # type: (numpy.ndarray) -> (int, numpy.ndarray, Dict[int,Tuple[int, int, int, int]])
     labels = label(image, background=0)
     cc = int(labels.max())
     bboxes = connected_components2bboxes(labels)
@@ -62,6 +67,7 @@ def compute_connected_components(image):
 
 
 def resolve_notehead_wrt_staffline(notehead, staffline_or_ledger_line):
+    # type: (CropObject, CropObject) -> int
     """Resolves the relative vertical position of the notehead with respect
     to the given staff_line or ledger_line object. Returns -1 if notehead
     is *below* staffline, 0 if notehead is *on* staffline, and 1 if notehead
@@ -119,17 +125,18 @@ def resolve_notehead_wrt_staffline(notehead, staffline_or_ledger_line):
             output_position = -1
 
         else:
-            logging.warn('Strange notehead {0} vs. ledger line {1}'
-                         ' situation: bbox notehead {2}, LL {3}.'
-                         ' Note that the output position is unusable;'
-                         ' pleasre re-do this attachment manually.'
-                         ''.format(notehead.uid, ll.uid,
-                                   notehead.bounding_box,
-                                   ll.bounding_box))
+            logging.warning('Strange notehead {0} vs. ledger line {1}'
+                            ' situation: bbox notehead {2}, LL {3}.'
+                            ' Note that the output position is unusable;'
+                            ' please re-do this attachment manually.'
+                            ''.format(notehead.uid, ll.uid,
+                                      notehead.bounding_box,
+                                      ll.bounding_box))
     return output_position
 
 
 def is_notehead_on_line(notehead, line_obj):
+    # type: (CropObject, CropObject) -> bool
     """Check whether given notehead is positioned on the line object."""
     if line_obj.clsname not in _CONST.STAFFLINE_LIKE_CROPOBJECT_CLSNAMES:
         raise ValueError('Cannot resolve relative position of notehead'

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,7 @@ typing
 # Libraries to integrating code-coverage reporting
 python-coveralls
 codecov
+
+# For inference and playing pieces
+midi2audio
+midiutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,9 @@ matplotlib
 midiutil>=1.2.1
 midi2audio>=0.1.1
 
+# Making type-hinting work in Python 2
+typing
+
 # Libraries to integrating code-coverage reporting
 python-coveralls
 codecov


### PR DESCRIPTION
Fixed #3 (mostly).

Added type-hints in a Python 2.7 compatible manner to all major methods to allow a modern IDE like PyCharm to provide meaningful type-hints.

Please verify, that the correct types were used. This process actually revealed some inconsistencies, that might lead to problems during execution, e.g. the bounding box coordinates are sometimes refered to as float, sometimes int, but some methods only accept int, which would result in a crash.

Also added the necessary libraries and missing ones to the requirements.txt document.