### PR TITLE
Adding Python 2-compatible type-hints

### DIFF
--- a/muscima/cropobject.py
+++ b/muscima/cropobject.py
@@ -253,14 +253,14 @@ class CropObject(object):
     def __init__(self,
                  objid,  # type: int
                  clsname,  # type: str
-                 top,  # type: int
-                 left,  # type: int
-                 width,  # type: int
-                 height,  # type: int
-                 outlinks=None, # type: Optional[List[int]]
-                 inlinks=None,# type: Optional[List[int]]
+                 top,  # type: float
+                 left,  # type: float
+                 width,  # type: float
+                 height,  # type: float
+                 outlinks=None,  # type: Optional[List[int]]
+                 inlinks=None,  # type: Optional[List[int]]
                  mask=None,  # type: numpy.ndarray
-                 uid=None, # type: str
+                 uid=None,  # type: str
                  data=None
                  ):
         # type: (...) -> None
@@ -409,6 +409,7 @@ class CropObject(object):
             self.parse_uid()
 
     def set_doc(self, docname):
+        # type: (str) -> None
         new_uid = self.UID_DELIMITER.join([self._dataset_namespace,
                                            docname,
                                            str(self._instance)])

--- a/muscima/cropobject.py
+++ b/muscima/cropobject.py
@@ -253,17 +253,16 @@ class CropObject(object):
     def __init__(self,
                  objid,  # type: int
                  clsname,  # type: str
-                 top,  # type: float
-                 left,  # type: float
-                 width,  # type: float
-                 height,  # type: float
+                 top,  # type: int
+                 left,  # type: int
+                 width,  # type: int
+                 height,  # type: int
                  outlinks=None,  # type: Optional[List[int]]
                  inlinks=None,  # type: Optional[List[int]]
                  mask=None,  # type: numpy.ndarray
                  uid=None,  # type: str
                  data=None
                  ):
-        # type: (...) -> None
         # logging.debug('Initializing CropObject with objid {0}, uid {5}, x={1},'
         #              ' y={2}, h={3}, w={4}'
         #               ''.format(objid, top, left, height, width, uid))
@@ -389,11 +388,13 @@ class CropObject(object):
 
     @staticmethod
     def build_uid(global_name, document_name, numid):
+        # type: (Any, Any, Any) -> str
         return CropObject.UID_DELIMITER.join([str(global_name),
                                               str(document_name),
                                               str(numid)])
 
     def set_uid(self, uid):
+        # type: (str) -> None
         """Assigns the given ``uid`` to the CropObject. This is the way
         to do it, do not assign directly to ``cropobject.uid``! You need
         to update other things (and perform integrity checks) when changing
@@ -416,12 +417,14 @@ class CropObject(object):
         self.set_uid(new_uid)
 
     def set_dataset(self, dataset_name):
+        # type: (str) -> None
         new_uid = self.UID_DELIMITER.join([dataset_name,
                                            self._document_namespace,
                                            str(self._instance)])
         self.set_uid(new_uid)
 
     def set_mask(self, mask):
+        # type: (numpy.ndarray) -> None
         """Sets the CropObject's mask to the given array. Performs
         some compatibilty checks: size, dtype (converts to ``uint8``)."""
         if mask is None:
@@ -443,6 +446,7 @@ class CropObject(object):
             self.mask = mask.astype('uint8')
 
     def set_objid(self, objid):
+        # type: (int) -> None
         """Changes the objid and updates the UID with it.
         Do NOT use this unless you know what you're doing;
         changing the objid should be (1) checked against objid
@@ -453,6 +457,7 @@ class CropObject(object):
         self._sync_objid_to_uid()
 
     def _sync_objid_to_uid(self):
+        # type: () -> None
         """Resets the UID number to reflect the objid."""
         g_name, doc_name, num = self._parse_uid(self.uid)
         new_uid = self.build_uid(g_name, doc_name, self.objid)
@@ -460,6 +465,7 @@ class CropObject(object):
 
     @property
     def dataset(self):
+        # type: () -> str
         """Which dataset is this CropObject coming from?
         For bookkeeping."""
         # The ``_dataset_namespace`` is set during initialization.
@@ -467,6 +473,7 @@ class CropObject(object):
 
     @property
     def doc(self):
+        # type: () -> str
         """Which document within the dataset is this CropObject
         coming from? The ``_document_namespace``
 
@@ -483,34 +490,40 @@ class CropObject(object):
 
     @property
     def top(self):
+        # type: () -> int
         """Row coordinate of upper left corner."""
         return self.x
 
     @property
     def bottom(self):
+        # type: () -> int
         """Row coordinate 1 beyond bottom right corner, so that indexing
         in the form ``img[c.top:c.bottom]`` is possible."""
         return self.x + self.height
 
     @property
     def left(self):
+        # type: () -> int
         """Column coordinate of upper left corner."""
         return self.y
 
     @property
     def right(self):
+        # type: () -> int
         """Column coordinate 1 beyond bottom right corner, so that indexing
         in the form ``img[:, c.left:c.right]`` is possible."""
         return self.y + self.width
 
     @property
     def bounding_box(self):
+        # type: () -> (int, int, int, int)
         """The ``top, left, bottom, right`` tuple of the CropObject's
         coordinates."""
         return self.top, self.left, self.bottom, self.right
 
     @property
     def middle(self):
+        # type: () -> (int, int)
         """Returns the integer representation of where the middle
         of the CropObject lies, as a ``(m_vert, m_horz)`` tuple.
 
@@ -522,6 +535,7 @@ class CropObject(object):
 
     @property
     def is_empty(self):
+        # type: () -> bool
         """A CropObject is empty if it is composed of zero pixels.
         This is measured through the mask. CropObjects without
         a mask are assumed to be non-empty."""
@@ -532,10 +546,12 @@ class CropObject(object):
 
     @property
     def outlink_uids(self):
+        # type: () -> List[str]
         return [self.build_uid(self.dataset, self.doc, o) for o in self.outlinks]
 
     @property
     def inlink_uids(self):
+        # type: () -> List[str]
         return [self.build_uid(self.dataset, self.doc, i) for i in self.inlinks]
 
     @staticmethod
@@ -577,6 +593,7 @@ class CropObject(object):
         return int(top), int(left), int(bottom), int(right)
 
     def to_integer_bounds(self):
+        # type: () -> None
         """Ensures that the CropObject has an integer position and size.
         (This is important whenever you want to use a mask, and reasonable
         whenever you do not need sub-pixel resolution...)
@@ -592,6 +609,7 @@ class CropObject(object):
         self.width = width
 
     def project_to(self, img):
+        # type: (numpy.ndarray) -> numpy.ndarray
         """This function returns the *crop* of the input image
         corresponding to the CropObject (incl. masking).
         Assumes zeros are background."""
@@ -603,6 +621,7 @@ class CropObject(object):
         return crop
 
     def project_on(self, img):
+        # type: (numpy.ndarray) -> numpy.ndarray
         """This function returns only those parts of the input image
         that correspond to the CropObject and masks out everything else
         with zeros. The dimension of the returned array is the same
@@ -637,7 +656,7 @@ class CropObject(object):
         return img
 
     def overlaps(self, bounding_box_or_cropobject):
-        # type: (Union[Tuple[float,float,float,float],CropObject]) -> bool
+        # type: (Union[Tuple[int,int,int,int],CropObject]) -> bool
         """Check whether this CropObject overlaps the given bounding box or CropObject.
 
         >>> c = CropObject(0, 'test', 10, 100, height=20, width=10)
@@ -697,6 +716,7 @@ class CropObject(object):
         return False
 
     def bbox_intersection(self, bounding_box):
+        # type: (Tuple[int,int, int, int]) -> Optional[Tuple[int,int, int, int]]
         """Returns the sub-bounding box of this CropObject, relative to its size (so: 0,0
         is the CropObject's upper left corner), that intersects the given bounding box.
         If the intersection is empty, returns None.
@@ -734,6 +754,7 @@ class CropObject(object):
             return None
 
     def crop_to_mask(self):
+        # type: () -> None
         """Crops itself to the minimum bounding box that contains all
         its pixels, as determined by its mask.
 
@@ -849,6 +870,7 @@ class CropObject(object):
         return '\n'.join(lines)
 
     def encode_mask(self, mask, compress=False, mode='rle'):
+        # type: (numpy.ndarray, bool, str) -> str
         """Encode a binary array ``mask`` as a string, compliant
         with the CropObject format specification in :mod:`muscima.io`.
         """
@@ -858,6 +880,7 @@ class CropObject(object):
             return self.encode_mask_bitmap(mask, compress=compress)
 
     def encode_data(self, data):
+        # type: () -> Optional[str]
         if self.data is None:
             return None
         if len(self.data) == 0:
@@ -901,6 +924,7 @@ class CropObject(object):
 
     @staticmethod
     def encode_mask_bitmap(mask, compress=False):
+        # type: (numpy.ndarray, bool) -> str
         """Encodes the mask array in a compact form. Returns 'None' if mask
         is None. If the mask is not None, uses the following algorithm:
 
@@ -920,6 +944,7 @@ class CropObject(object):
 
     @staticmethod
     def encode_mask_rle(mask, compress=False):
+        # type: (numpy.ndarray, bool) -> str
         """Encodes the mask array in Run-Length Encoding. Instead of
         having the bitmap ``0 0 1 1 1 0 0 0 1 1``, the RLE encodes
         the mask as ``0:2 1:3 0:3 1:2``. This is much more compact.
@@ -950,6 +975,7 @@ class CropObject(object):
         return output
 
     def decode_mask(self, mask_string, shape):
+        # type: (str, Tuple[Any, ...]) -> Optional[numpy.ndarray]
         """Decodes a CropObject mask string into a binary
         numpy array of the given shape."""
         mode = self._determine_mask_mode(mask_string)
@@ -959,6 +985,7 @@ class CropObject(object):
             return self.decode_mask_bitmap(mask_string, shape=shape)
 
     def _determine_mask_mode(self, mask_string):
+        # type: (str) -> str
         """If the mask string starts with '0:' or '1:', or generally
         if it contains a non-0 or 1 symbol, assume it is RLE."""
         mode = 'bitmap'
@@ -970,6 +997,7 @@ class CropObject(object):
 
     @staticmethod
     def decode_mask_bitmap(mask_string, shape):
+        # type: (str, Tuple[Any, ...]) -> Optional[numpy.ndarray]
         """Decodes the mask array from the encoded form to the 2D numpy array."""
         if mask_string == 'None':
             return None
@@ -986,6 +1014,7 @@ class CropObject(object):
 
     @staticmethod
     def decode_mask_rle(mask_string, shape):
+        # type: (str, Tuple[Any, ...]) -> Optional[numpy.ndarray]
         """Decodes the mask array from the RLE-encoded form
         to the 2D numpy array.
         """
@@ -1003,6 +1032,7 @@ class CropObject(object):
         return mask
 
     def join(self, other):
+        # type: (CropObject) -> None
         """CropObject "addition": performs an OR on this
         and the ``other`` CropObjects' masks and bounding boxes,
         and assigns to this CropObject the result. Merges
@@ -1060,6 +1090,7 @@ class CropObject(object):
                 self.inlinks.append(i)
 
     def get_outlink_objects(self, cropobjects):
+        # type: (List[CropObject]) -> List[CropObject]
         """Out of the given ``cropobject`` list, return a list
         of those to which this CropObject has outlinks.
 
@@ -1081,6 +1112,7 @@ class CropObject(object):
         return output
 
     def get_inlink_objects(self, cropobjects):
+        # type: (List[CropObject]) -> List[CropObject]
         """Out of the given ``cropobject`` list, return a list
         of those from which this CropObject has inlinks.
 
@@ -1102,6 +1134,7 @@ class CropObject(object):
         return output
 
     def translate(self, down=0, right=0):
+        # type: (int, int) -> None
         """Move the cropobject down and right by the given amount of pixels."""
         self.x += down
         self.y += right
@@ -1130,6 +1163,7 @@ class CropObject(object):
 ##############################################################################
 # Functions for merging CropObjects and CropObjectLists
 def split_cropobject_on_connected_components(c, next_objid):
+    # type: (CropObject, int) -> List[CropObject]
     """Split the CropObject into one object per connected component
     of the mask. All inlinks/outlinks are retained in all the newly
     created CropObjects, and the old object is not changed. (If there
@@ -1183,6 +1217,7 @@ def split_cropobject_on_connected_components(c, next_objid):
 
 
 def cropobjects_merge(fr, to, clsname, objid):
+    # type: (CropObject, CropObject, str, int) -> CropObject
     """Merge the given CropObjects with respect to the other.
     Returns the new CropObject (without modifying any of the inputs)."""
     if fr.doc != to.doc:
@@ -1229,6 +1264,7 @@ def cropobjects_merge_multiple(cropobjects, clsname, objid):
 
 
 def cropobjects_merge_bbox(cropobjects):
+    # type: (List[CropObject]) -> (int, int, int, int)
     """Computes the bounding box of a CropObject that would
     result from merging the given list of CropObjects.
     """
@@ -1249,6 +1285,7 @@ def cropobjects_merge_bbox(cropobjects):
 
 
 def cropobjects_merge_mask(cropobjects, intersection=False):
+    # type: (List[CropObject], bool) -> Optional[numpy.ndarray]
     """Merges the given list of cropobjects into one. Masks are combined
     by an OR operation.
 
@@ -1311,6 +1348,7 @@ def cropobjects_merge_mask(cropobjects, intersection=False):
 
 
 def cropobjects_merge_links(cropobjects):
+    # type: (List[CropObject]) -> (List[CropObject], List[CropObject])
     """Collect all inlinks and outlinks of the given set of CropObjects
     to CropObjects outside of this set. The rationale for this is that
     these given ``cropobjects`` will be merged into one, so relationships
@@ -1335,6 +1373,7 @@ def cropobjects_merge_links(cropobjects):
 
 
 def merge_cropobject_lists(*cropobject_lists):
+    # type: (List[List[CropObject]]) -> List[CropObject]
     """Combines the CropObject lists from different documents
     into one list, so that inlink/outlink references still work.
     This is useful only if you want to merge two documents
@@ -1388,6 +1427,7 @@ def merge_cropobject_lists(*cropobject_lists):
 
 
 def link_cropobjects(fr, to, check_docname=True):
+    # type: (CropObject, CropObject, bool) -> None
     """Add a relationship from the ``fr`` CropObject
     to the ``to`` CropObject. Modifies the CropObjects
     in-place.
@@ -1416,6 +1456,7 @@ def link_cropobjects(fr, to, check_docname=True):
 
 
 def bbox_intersection(bbox_this, bbox_other):
+    # type: (Tuple[int, int, int, int],Tuple[int, int, int, int]) -> Optional[Tuple[int, int, int, int]]
     """Returns the t, l, b, r coordinates of the sub-bounding box
     of bbox_this that is also inside bbox_other.
     If the bounding boxes do not overlap, returns None."""
@@ -1438,6 +1479,7 @@ def bbox_intersection(bbox_this, bbox_other):
 
 
 def bbox_dice(bbox_this, bbox_other, vertical=False, horizontal=False):
+    # type: (Tuple[int, int, int, int], Tuple[int, int, int, int], bool, bool) -> float
     """Compute the Dice coefficient (intersection over union)
     for the given two bounding boxes.
 
@@ -1479,6 +1521,7 @@ def bbox_dice(bbox_this, bbox_other, vertical=False, horizontal=False):
 
 
 def cropobject_distance(c, d):
+    # type: (CropObject, CropObject) -> numpy.ndarray
     """Computes the distance between two CropObjects.
     Their minimum vertical and horizontal distances are each taken
     separately, and the euclidean norm is computed from them."""
@@ -1511,6 +1554,7 @@ def cropobject_distance(c, d):
 
 
 def cropobjects_on_canvas(cropobjects, margin=10):
+    # type: (List[CropObject], int) -> (numpy.ndarray, Tuple[int, int])
     """Draws all the given CropObjects onto a zero background.
     The size of the canvas adapts to the CropObjects, with the
     given margin.

--- a/muscima/cropobject.py
+++ b/muscima/cropobject.py
@@ -11,7 +11,7 @@ from builtins import object
 import copy
 import itertools
 import logging
-from typing import Any, Optional, List
+from typing import Any, Optional, List, Union, Tuple
 
 import numpy
 
@@ -540,6 +540,7 @@ class CropObject(object):
 
     @staticmethod
     def bbox_to_integer_bounds(ftop, fleft, fbottom, fright):
+        # type: (float,float,float,float) -> (int,int,int,int)
         """Rounds off the CropObject bounds to the nearest integer
         so that no area is lost (e.g. bottom and right bounds are
         rounded up, top and left bounds are rounded down).
@@ -614,6 +615,7 @@ class CropObject(object):
         return output
 
     def render(self, img, alpha=0.3, rgb=(1.0, 0.0, 0.0)):
+        # type: (numpy.ndarray, float, Tuple[float,float,float]) -> numpy.ndarray
         """Renders itself upon the given image as a rectangle
         of the given color and transparency. Might help visualization.
 
@@ -635,6 +637,7 @@ class CropObject(object):
         return img
 
     def overlaps(self, bounding_box_or_cropobject):
+        # type: (Union[Tuple[float,float,float,float],CropObject]) -> bool
         """Check whether this CropObject overlaps the given bounding box or CropObject.
 
         >>> c = CropObject(0, 'test', 10, 100, height=20, width=10)

--- a/muscima/cropobject_class.py
+++ b/muscima/cropobject_class.py
@@ -43,6 +43,7 @@ for annotating MUSCIMA++.
 from __future__ import division
 from builtins import object
 import logging
+from typing import Tuple
 
 __version__ = "1.0"
 __author__ = "Jan Hajic jr."
@@ -90,6 +91,7 @@ _hex_itr = {v: k for k, v in list(_hex_tr.items())}
 
 
 def parse_hex(hstr):
+    # type: (str) -> int
     """Convert a hexadecimal number string to integer.
 
     >>> parse_hex('33')
@@ -105,6 +107,7 @@ def parse_hex(hstr):
 
 
 def hex2rgb(hstr):
+    # type: (str) -> Tuple[float, float, float]
     """Parse a hex-coded color like '#AA0202' into a floating-point representation.
 
     >>> hex2rgb('#abe822')
@@ -119,6 +122,7 @@ def hex2rgb(hstr):
 
 
 def rgb2hex(rgb):
+    # type: (Tuple[float, float, float]) -> str
     """Convert a floating-point representation of R, G, B values
     between 0 and 1 (inclusive) to a hex string (strating with a
     hashmark). Will use uppercase letters for 10 - 15.

--- a/muscima/cropobject_class.py
+++ b/muscima/cropobject_class.py
@@ -60,6 +60,7 @@ class CropObjectClass(object):
     out in the appropriate XML format.
     """
     def __init__(self, clsid, name, group_name, color):
+        # type: (int, str, str, str) -> None
         self.clsid = clsid
         self.name = name
         self.group_name = group_name

--- a/muscima/dataset.py
+++ b/muscima/dataset.py
@@ -22,6 +22,7 @@ from builtins import range
 from builtins import object
 import logging
 import os
+from typing import Optional
 
 __version__ = "0.0.1"
 __author__ = "Jan Hajic jr."
@@ -31,6 +32,7 @@ __author__ = "Jan Hajic jr."
 
 
 def _get_cvc_muscima_root():
+    # type: () -> Optional[str]
     if 'CVC_MUSCIMA_ROOT' in os.environ:
         CVC_MUSCIMA_ROOT = os.environ['CVC_MUSCIMA_ROOT']
         return CVC_MUSCIMA_ROOT
@@ -38,12 +40,15 @@ def _get_cvc_muscima_root():
         logging.info('muscima.dataset: environmental variable CVC_MUSCIMA_ROOT not defined.')
         return None
 
+
 CVC_MUSCIMA_ROOT = _get_cvc_muscima_root()
+
 
 ##############################################################################
 
 
 def _get_mff_muscima_root():
+    # type: () -> Optional[str]
     if 'MUSCIMA_PLUSPLUS_ROOT' in os.environ:
         MUSCIMA_PLUSPLUS_ROOT = os.environ['MUSCIMA_PLUSPLUS_ROOT']
         return MUSCIMA_PLUSPLUS_ROOT
@@ -51,7 +56,9 @@ def _get_mff_muscima_root():
         logging.info('muscima.dataset: environmental variable MUSCIMA_PLUSPLUS_ROOT not defined.')
         return None
 
+
 MUSCIMA_PLUSPLUS_ROOT = _get_mff_muscima_root()
+
 
 ##############################################################################
 
@@ -84,6 +91,7 @@ class CVC_MUSCIMA(object):
     MODES = ['full', 'symbol', 'staff_only']
 
     def __init__(self, root=_get_cvc_muscima_root(), validate=False):
+        # type: (Optional[str], bool) -> None
         """The dataset is instantiated by providing the path to its root
         directory. If the ``CVC_MUSCIMA_ROOT`` variable is set, you do not
         have to provide anything."""
@@ -104,6 +112,7 @@ class CVC_MUSCIMA(object):
         self.root = root
 
     def imfile(self, page, writer, distortion='ideal', mode='full'):
+        # type: (int, int, str, str) -> str
         """Construct the path leading to the file of the CVC-MUSCIMA image
         with the specified page (1 - 20), writer (1 - 50), distortion
         (see ``CVC_MUSCIMA_DISTORTIONS``), and mode (``full``, ``symbol``,
@@ -132,6 +141,7 @@ class CVC_MUSCIMA(object):
         return fname
 
     def _number2page_file(self, n):
+        # type: (int) -> str
         if (n < 1) or (n > 20):
             raise ValueError('Invalid CVC-MUSCIMA score number {0}.'
                              ' Valid only between 1 and 20.'.format(n))
@@ -141,6 +151,7 @@ class CVC_MUSCIMA(object):
             return 'p0' + str(n) + '.png'
 
     def _number2writer_dir(self, n):
+        # type: (int) -> str
         if (n < 1) or (n > 50):
             raise ValueError('Invalid MUSCIMA writer number {0}.'
                              ' Valid only between 1 and 50.'.format(n))
@@ -150,6 +161,7 @@ class CVC_MUSCIMA(object):
             return 'w-' + str(n)
 
     def _mode2dir(self, mode):
+        # type: (str) -> str
         if mode == 'full':
             return 'image'
         elif mode == 'symbol':
@@ -158,6 +170,7 @@ class CVC_MUSCIMA(object):
             return 'gt'
 
     def validate(self, fail_early=True):
+        # type: (bool) -> bool
         """Checks whether the instantiated CVC_MUSCIMA instance really
         corresponds to the CVC-MUSCIMA dataset: all the 12 x 1000 expected
         CVC-MUSCIMA files should be present.

--- a/muscima/grammar.py
+++ b/muscima/grammar.py
@@ -33,6 +33,8 @@ import pprint
 
 import collections
 
+from typing import Union, Set, List
+
 __version__ = "0.0.1"
 __author__ = "Jan Hajic jr."
 
@@ -254,6 +256,7 @@ class DependencyGrammar(object):
     _MAX_CARD = 10000
 
     def __init__(self, grammar_filename, alphabet):
+        # type: (str, Union[Set[str], List[str]]) -> None
         """Initialize the Grammar: fill in alphabet and parse rules.
 
         :param grammar_filename: Path to a file that contains deprules

--- a/muscima/graph.py
+++ b/muscima/graph.py
@@ -10,6 +10,8 @@ import logging
 import operator
 
 from muscima.cropobject import CropObject, cropobject_mask_rpf
+from typing import Union, List, Optional, Dict, Tuple
+
 from muscima.inference_engine_constants import _CONST
 from muscima.utils import resolve_notehead_wrt_staffline
 
@@ -37,6 +39,7 @@ class NotationGraph(object):
         return len(self.cropobjects)
 
     def __to_objid(self, cropobject_or_objid):
+        # type: (Union[CropObject, int]) -> int
         if isinstance(cropobject_or_objid, CropObject):
             objid = cropobject_or_objid.objid
         else:
@@ -53,6 +56,7 @@ class NotationGraph(object):
         return edges
 
     def children(self, cropobject_or_objid, classes=None):
+        # type: (Union[CropObject, int], Optional[List[str]]) -> List[CropObject]
         """Find all children of the given node."""
         objid = self.__to_objid(cropobject_or_objid)
         if objid not in self._cdict:
@@ -69,6 +73,7 @@ class NotationGraph(object):
         return output
 
     def parents(self, cropobject_or_objid, classes=None):
+        # type: (Union[CropObject, int], Optional[List[str]]) -> List[CropObject]
         """Find all parents of the given node."""
         objid = self.__to_objid(cropobject_or_objid)
         if objid not in self._cdict:
@@ -85,6 +90,7 @@ class NotationGraph(object):
         return output
 
     def descendants(self, cropobject_or_objid, classes=None):
+        # type: (Union[CropObject, int], Optional[List[str]]) -> List[CropObject]
         """Find all descendants of the given node."""
         objid = self.__to_objid(cropobject_or_objid)
 
@@ -106,6 +112,7 @@ class NotationGraph(object):
         return [self._cdict[o] for o in descendant_objids]
 
     def ancestors(self, cropobject_or_objid, classes=None):
+        # type: (Union[CropObject, int], Optional[List[str]]) -> List[CropObject]
         """Find all ancestors of the given node."""
         objid = self.__to_objid(cropobject_or_objid)
 
@@ -127,14 +134,17 @@ class NotationGraph(object):
         return [self._cdict[objid] for objid in ancestor_objids]
 
     def has_child(self, cropobject_or_objid, classes=None):
+        # type: (Union[CropObject, int], Optional[List[str]]) -> bool
         children = self.children(cropobject_or_objid, classes=classes)
         return len(children) > 0
 
     def has_parent(self, cropobject_or_objid, classes=None):
+        # type: (Union[CropObject, int], Optional[List[str]]) -> bool
         parents = self.parents(cropobject_or_objid, classes=classes)
         return len(parents) > 0
 
     def is_child_of(self, cropobject_or_objid, other_cropobject_or_objid):
+        # type: (Union[CropObject, int], Union[CropObject,int]) -> bool
         """Check whether the first symbol is a child of the second symbol."""
         to_objid = self.__to_objid(cropobject_or_objid)
         from_objid = self.__to_objid(other_cropobject_or_objid)
@@ -146,6 +156,7 @@ class NotationGraph(object):
             return False
 
     def is_parent_of(self, cropobject_or_objid, other_cropobject_or_objid):
+        # type: (Union[CropObject, int], Union[CropObject,int]) -> bool
         """Check whether the first symbol is a parent of the second symbol."""
         from_objid = self.__to_objid(cropobject_or_objid)
         to_objid = self.__to_objid(other_cropobject_or_objid)
@@ -157,10 +168,12 @@ class NotationGraph(object):
             return False
 
     def __getitem__(self, objid):
+        # type: (int) -> CropObject
         """Returns a CropObject based on its objid."""
         return self._cdict[objid]
 
     def is_stem_direction_above(self, notehead, stem):
+        # type: (CropObject, CropObject) -> bool
         """Determines whether the given stem of the given notehead
         is above it or below. This is not trivial due to chords.
         """
@@ -184,6 +197,7 @@ class NotationGraph(object):
         return d_top > d_bottom
 
     def is_symbol_above_notehead(self, notehead, other, compare_on_intersect=False):
+        # type: (CropObject, CropObject, bool) -> bool
         """Determines whether the given other symbol is above
         the given notehead.
 
@@ -215,9 +229,9 @@ class NotationGraph(object):
         # Get vertical bounds of beam submask
         other_submask_hsum = beam_submask.sum(axis=1)
         other_submask_top = min([i for i in range(beam_submask.shape[0])
-                                if other_submask_hsum[i] != 0]) + other.top
+                                 if other_submask_hsum[i] != 0]) + other.top
         other_submask_bottom = max([i for i in range(beam_submask.shape[0])
-                                   if other_submask_hsum[i] != 0]) + other.top
+                                    if other_submask_hsum[i] != 0]) + other.top
         if (notehead.top <= other_submask_top <= notehead.bottom) \
                 or (other_submask_bottom <= notehead.top <= other_submask_bottom):
             if compare_on_intersect:
@@ -454,6 +468,7 @@ def group_staffs_into_systems(cropobjects,
 
 
 def group_by_staff(cropobjects):
+    # type: (List[CropObject]) -> Dict[int, List[CropObject]]
     """Returns one NotationGraph instance for each staff and its associated
     CropObjects. "Associated" means:
 
@@ -489,6 +504,7 @@ def group_by_staff(cropobjects):
 
 def find_related_staffs(query_cropobjects, all_cropobjects,
                         with_stafflines=True):
+    # type: (List[CropObject], List[CropObject], bool) -> List[CropObject]
     """Find all staffs that are related to any of the cropobjects
     in question. Ignores whether these staffs are already within
     the list of ``query_cropobjects`` passed to the function.
@@ -519,7 +535,7 @@ def find_related_staffs(query_cropobjects, all_cropobjects,
     related_staffs = set()
     for c in query_cropobjects:
         desc_staffs = graph.descendants(c, classes=[_CONST.STAFF_CLSNAME])
-        anc_staffs =  graph.ancestors(c, classes=[_CONST.STAFF_CLSNAME])
+        anc_staffs = graph.ancestors(c, classes=[_CONST.STAFF_CLSNAME])
         current_staffs = set(desc_staffs + anc_staffs)
         related_staffs = related_staffs.union(current_staffs)
 
@@ -542,6 +558,7 @@ def find_related_staffs(query_cropobjects, all_cropobjects,
 
 
 def find_beams_incoherent_with_stems(cropobjects):
+    # type: (List[CropObject]) -> List[Tuple[CropObject,CropObject]]
     """Searches the graph for edges where a notehead is connected to a stem
     in one direction, but is connected to beams that are in the
     other direction.
@@ -592,6 +609,7 @@ def find_beams_incoherent_with_stems(cropobjects):
 # *AND* a ledger line.
 
 def find_ledger_lines_with_noteheads_from_both_directions(cropobjects):
+    # type: (List[CropObject]) -> List[CropObject]
     """Looks for ledger lines that have inlinks from noteheads
     on both sides. Returns a list of ledger line CropObjects."""
     graph = NotationGraph(cropobjects)
@@ -617,6 +635,7 @@ def find_ledger_lines_with_noteheads_from_both_directions(cropobjects):
 
 
 def find_noteheads_with_ledger_line_and_staff_conflict(cropobjects):
+    # type: (List[CropObject]) -> List[CropObject]
     """Find all noteheads that have a relationship both to a staffline
     or staffspace and to a ledger line.
 
@@ -709,8 +728,8 @@ def find_misdirected_ledger_line_edges(cropobjects,
 
         staffs = graph.children(c, ['staff'])
         if not staffs:
-            logging.warn('Notehead {0} not connected to any staff!'
-                         ''.format(c.uid))
+            logging.warning('Notehead {0} not connected to any staff!'
+                            ''.format(c.uid))
             continue
         staff = staffs[0]
 
@@ -751,6 +770,7 @@ def find_misdirected_ledger_line_edges(cropobjects,
 
 
 def resolve_ledger_line_or_staffline_object(cropobjects):
+    # type: (List[CropObject]) -> None
     """If staff relationships are created before notehead to ledger line
     relationships, then there will be noteheads on ledger lines that
     are nevertheless connected to staffspaces. This function should be
@@ -779,8 +799,8 @@ def resolve_ledger_line_or_staffline_object(cropobjects):
             continue
 
         if len(staff) == 0:
-            logging.warn('Notehead {0} not connected to any staff!'
-                         ' Unable to resolve ll/staffline.'.format(c.uid))
+            logging.warning('Notehead {0} not connected to any staff!'
+                            ' Unable to resolve ll/staffline.'.format(c.uid))
             continue
 
         # Multiple LLs: must check direction

--- a/muscima/inference.py
+++ b/muscima/inference.py
@@ -10,8 +10,11 @@ import logging
 import os
 
 import operator
+from typing import Optional, Any, Dict, Union, List, Tuple
 
-from muscima.cropobject import bbox_dice
+from midiutil import MIDIFile
+
+from muscima.cropobject import bbox_dice, CropObject
 from muscima.graph import group_staffs_into_systems, NotationGraph, NotationGraphError
 from muscima.inference_engine_constants import InferenceEngineConstants
 
@@ -111,10 +114,11 @@ class PitchInferenceEngineState(object):
         '''If the clef is in a non-standard position, this number is added
         to the pitch computation delta.'''
 
-        self.key_accidentals = {}
-        self.inline_accidentals = {}
+        self.key_accidentals = {}  # type: Dict[int, str]
+        self.inline_accidentals = {}  # type: Dict[int, str]
 
     def reset(self):
+        # type: () -> None
         self.base_pitch = None
         self._current_clef = None
         self._current_delta_steps = None
@@ -138,12 +142,14 @@ class PitchInferenceEngineState(object):
         return '\n'.join(lines)
 
     def init_base_pitch(self, clef=None, delta=0):
+        # type: (Optional[CropObject], int) -> None
         """Initializes the base pitch while taking into account
         the displacement of the clef from its initial position."""
         self.init_base_pitch_default_staffline(clef)
         self._current_clef_delta_shift = -1 * delta
 
     def init_base_pitch_default_staffline(self, clef=None):
+        # type: (Optional[CropObject]) -> None
         """Based solely on the clef class name and assuming
         default stafflines, initialize the base pitch.
         By default, initializes as though given a g-clef."""
@@ -195,6 +201,7 @@ class PitchInferenceEngineState(object):
         self._current_delta_steps = new_delta_steps
 
     def set_key(self, n_sharps=0, n_flats=0):
+        # type: (int, int) -> None
         """Initialize the staffline delta --> key accidental map.
         Currently works only on standard key signatures, where
         there are no repeating accidentals, no double sharps/flats,
@@ -236,18 +243,21 @@ class PitchInferenceEngineState(object):
         self.key_accidentals = new_key_accidentals
 
     def set_inline_accidental(self, delta, accidental):
+        # type: (int, CropObject) -> None
         self.inline_accidentals[delta] = accidental.clsname
 
     def reset_inline_accidentals(self):
+        # type: () -> None
         self.inline_accidentals = {}
 
     def accidental(self, delta):
+        # type: (int) -> int
         """Returns the modification, in MIDI code, corresponding
         to the staffline given by the delta."""
         pitch_mod = 0
 
         step_delta = delta % 7
-        if step_delta in self.key_accidentals:
+        if step_delta in self.key_accidentals:  # type: int
             if self.key_accidentals[step_delta] == 'sharp':
                 pitch_mod = 1
             elif self.key_accidentals[step_delta] == 'double_sharp':
@@ -273,6 +283,7 @@ class PitchInferenceEngineState(object):
         return pitch_mod
 
     def pitch(self, delta):
+        # type: (int) -> int
         """Given a staffline delta, returns the current MIDI pitch code.
 
         (This method is the main interface of the PitchInferenceEngineState.)
@@ -305,6 +316,7 @@ class PitchInferenceEngineState(object):
         return pitch
 
     def pitch_name(self, delta):
+        # type: (int) -> (str, int)
         """Given a staffline delta, returns the name of the corrensponding pitch."""
         delta += self._current_clef_delta_shift
 
@@ -416,6 +428,7 @@ class PitchInferenceEngine(object):
         self.__init__()
 
     def infer_pitches(self, cropobjects, with_names=False):
+        # type: (List[CropObject], bool) -> Union[Dict, Tuple[Dict, Dict]]
         """The main workhorse for pitch inference.
         Gets a list of CropObjects and for each notehead-type
         symbol, outputs a MIDI code corresponding to the pitch
@@ -481,7 +494,7 @@ class PitchInferenceEngine(object):
         # self.durations_beats = {}
         # self.durations_beats_per_staff = {}
 
-        for staff in self.staves:
+        for staff in self.staves: # type: CropObject
             self.process_staff(staff)
             self.pitches.update(self.pitches_per_staff[staff.objid])
 
@@ -491,7 +504,7 @@ class PitchInferenceEngine(object):
             return copy.deepcopy(self.pitches)
 
     def process_staff(self, staff):
-
+        #type: (CropObject) -> Any
         self.pitches_per_staff[staff.objid] = {}
         self.pitch_names_per_staff[staff.objid] = {}
 
@@ -816,7 +829,7 @@ class PitchInferenceEngine(object):
         graph = NotationGraph(cropobjects)
 
         # Collect staves.
-        self.staves = [c for c in cropobjects if c.clsname == 'staff']
+        self.staves = [c for c in cropobjects if c.clsname == 'staff'] # type: List[CropObject]
         logging.info('We have {0} staves.'.format(len(self.staves)))
 
         # Collect clefs and key signatures per staff.
@@ -2424,10 +2437,8 @@ def play_midi(midi,
               soundfont='~/.fluidsynth/FluidR3_GM.sf2',
               cleanup=False):
     """Plays (or attempts to play) the given MIDIFile object.
-
     :param midi: A ``midiutils.MidiFile.MIDIFile`` object
         containing the data that you wish to play.
-
     :param tmp_dir: A writeable directory where the MIDI will be
         exported into a temporary file.
 

--- a/muscima/inference.py
+++ b/muscima/inference.py
@@ -87,6 +87,7 @@ class PitchInferenceEngineState(object):
     Iterate through the relevant objects on a staff, sorted left-to-right
     by left edge.
     """
+
     def __init__(self):
 
         self.base_pitch = None
@@ -289,7 +290,7 @@ class PitchInferenceEngineState(object):
 
         # From the base pitch and clef:
         step_pitch = self.base_pitch \
-                     + sum(self._current_delta_steps[:delta_step+1]) \
+                     + sum(self._current_delta_steps[:delta_step + 1]) \
                      + (delta_octave * 12)
         accidental_pitch = self.accidental(delta)
 
@@ -500,11 +501,11 @@ class PitchInferenceEngine(object):
         self.pitch_state.init_base_pitch()
 
         queue = sorted(
-                    self.staff_to_clef_map[staff.objid]
-                    + self.staff_to_key_map[staff.objid]
-                    + self.staff_to_msep_map[staff.objid]
-                    + self.staff_to_noteheads_map[staff.objid],
-                    key=lambda x: x.left)
+            self.staff_to_clef_map[staff.objid]
+            + self.staff_to_key_map[staff.objid]
+            + self.staff_to_msep_map[staff.objid]
+            + self.staff_to_noteheads_map[staff.objid],
+            key=lambda x: x.left)
 
         for q in queue:
             logging.info('process_staff(): processing object {0}-{1}'
@@ -666,7 +667,7 @@ class PitchInferenceEngine(object):
             #    then it would be weird to find out it is in the
             #    mini-staffspace *below* the closest ledger line,
             #    signalling a mistake in the data.
-            closest_ll = min(lls, key=lambda x: (x.top - notehead.top)**2 + (x.bottom - notehead.bottom)**2)
+            closest_ll = min(lls, key=lambda x: (x.top - notehead.top) ** 2 + (x.bottom - notehead.bottom) ** 2)
 
             # Determining whether the notehead is on a ledger
             # line or in the adjacent temp staffspace.
@@ -859,7 +860,7 @@ class PitchInferenceEngine(object):
 
         # Collect measure separators.
         self.measure_separators = [c for c in cropobjects
-                              if c.clsname == 'measure_separator']
+                                   if c.clsname == 'measure_separator']
         if ignore_nonstaff:
             self.measure_separators = [c for c in self.measure_separators
                                        if graph.has_child(c, ['staff'])]
@@ -1001,7 +1002,7 @@ class OnsetsInferenceEngine(object):
             if len(stems) == 0:
                 self.__warning_or_error('Full notehead {0} has no stem!'.format(notehead.uid))
 
-            beat = [0.5**len(flags_and_beams)]
+            beat = [0.5 ** len(flags_and_beams)]
 
         else:
             raise ValueError('Notehead {0}: unknown clsname {1}'
@@ -1100,7 +1101,7 @@ class OnsetsInferenceEngine(object):
             for whole rests.
 
         """
-        rest_beats_dict = {'whole_rest': 4,   # !!! We should find the Time Signature.
+        rest_beats_dict = {'whole_rest': 4,  # !!! We should find the Time Signature.
                            'half_rest': 2,
                            'quarter_rest': 1,
                            '8th_rest': 0.5,
@@ -1228,8 +1229,8 @@ class OnsetsInferenceEngine(object):
                 f_and_b_below.append(c)
                 print('Appending below')
 
-        beat_above = 0.5**len(f_and_b_above)
-        beat_below = 0.5**len(f_and_b_below)
+        beat_above = 0.5 ** len(f_and_b_above)
+        beat_below = 0.5 ** len(f_and_b_below)
 
         if beat_above != beat_below:
             raise NotImplementedError('Cannot deal with multi-stem note'
@@ -1619,7 +1620,7 @@ class OnsetsInferenceEngine(object):
 
         # Create measure bins. i-th measure ENDS at i-th ordered msep.
         # We assume that every measure has a rightward separator.
-        measures = [(None, ordered_mseps[0])] + [(ordered_mseps[i], ordered_mseps[i+1])
+        measures = [(None, ordered_mseps[0])] + [(ordered_mseps[i], ordered_mseps[i + 1])
                                                  for i in range(len(ordered_mseps) - 1)]
         measure_nodes = [PrecedenceGraphNode(objid=None,
                                              cropobject=None,
@@ -1629,8 +1630,8 @@ class OnsetsInferenceEngine(object):
                                              onset=None)] + \
                         [PrecedenceGraphNode(objid=None,
                                              cropobject=None,
-                                             inlinks=[ordered_msep_nodes[i+1]],
-                                             outlinks=[ordered_msep_nodes[i+2]],
+                                             inlinks=[ordered_msep_nodes[i + 1]],
+                                             outlinks=[ordered_msep_nodes[i + 2]],
                                              duration=0,  # Durations will be filled in
                                              onset=None)
                          for i in range(len(ordered_msep_nodes) - 2)]
@@ -1777,7 +1778,7 @@ class OnsetsInferenceEngine(object):
                 msep_to_staff_projections[msep.objid][s.objid] = intersection_bbox
 
         staff_and_measure_to_objs_map = collections.defaultdict(
-                                            collections.defaultdict(list))
+            collections.defaultdict(list))
         #: Per staff (indexed by objid) and measure (by order no.), keeps a list of
         #  CropObjects from that staff that fall within that measure.
 
@@ -1788,7 +1789,7 @@ class OnsetsInferenceEngine(object):
         for s_objid, objs in list(ordered_objs_per_staff.items()):
             # Vertically, we don't care -- the attachment to staff takes
             # care of that, we only need horizontal placement.
-            _c_m_idx = 0   # Index of current measure
+            _c_m_idx = 0  # Index of current measure
             _c_msep_right = measure_nodes[_c_m_idx].outlinks[0]
             # Left bound of current measure's right measure separator
             _c_m_right = msep_to_staff_projections[_c_msep_right.objid][s_objid][1]
@@ -2277,6 +2278,7 @@ class PrecedenceGraphNode(object):
     The ``inlinks`` and ``outlinks`` attributes are lists
     of other ``PrecedenceGraphNode`` instances.
     """
+
     def __init__(self, objid=None, cropobject=None, inlinks=None, outlinks=None,
                  onset=None, duration=0):
         # Optional link to CropObjects, or just a placeholder ID.
@@ -2390,10 +2392,10 @@ class MIDIBuilder(object):
         from midiutil.MidiFile import MIDIFile
 
         # create your MIDI object
-        mf = MIDIFile(1)     # only 1 track
-        track = 0   # the only track
+        mf = MIDIFile(1)  # only 1 track
+        track = 0  # the only track
 
-        time = 0    # start at the beginning
+        time = 0  # start at the beginning
         mf.addTrackName(track, time, "Sample Track")
         mf.addTempo(track, time, tempo)
 

--- a/muscima/inference_engine_constants.py
+++ b/muscima/inference_engine_constants.py
@@ -6,6 +6,8 @@ from builtins import range
 from builtins import object
 import operator
 
+from typing import List, Set
+
 __version__ = "0.0.1"
 __author__ = "Jan Hajic jr."
 
@@ -14,11 +16,11 @@ class InferenceEngineConstants(object):
     """This class stores the constants used for pitch inference."""
 
     ON_STAFFLINE_RATIO_TRHESHOLD = 0.2
-    '''Magic number for determining whether a notehead is *on* a ledger
+    """Magic number for determining whether a notehead is *on* a ledger
     line, or *next* to a ledger line: if the ratio between the smaller
     and larger vertical difference of (top, bottom) vs. l.l. (top, bottom)
     is smaller than this, it means the notehead is most probably *NOT*
-    on the l.l. and is next to it.'''
+    on the l.l. and is next to it."""
 
     STAFFLINE_CLSNAME = 'staff_line'
     STAFFSPACE_CLSNAME = 'staff_space'
@@ -82,7 +84,7 @@ class InferenceEngineConstants(object):
         'beam',
     }
 
-    FLAGS_AND_BEAMS ={
+    FLAGS_AND_BEAMS = {
         '8th_flag',
         '16th_flag',
         '32th_flag',
@@ -112,7 +114,7 @@ class InferenceEngineConstants(object):
         10: 'Bb',
         11: 'B',
     }
-    '''Simplified pitch naming.'''
+    """Simplified pitch naming."""
 
     # The individual MIDI codes for for the unmodified steps.
     _fs = list(range(5, 114, 12))
@@ -223,6 +225,7 @@ class InferenceEngineConstants(object):
 
     @property
     def clsnames_affecting_onsets(self):
+        # type: () -> Set[str]
         """Returns a list of CropObject class names for objects
         that affect onsets. Assumes notehead and rest durations
         have already been given."""
@@ -236,6 +239,7 @@ class InferenceEngineConstants(object):
 
     @property
     def clsnames_bearing_duration(self):
+        # type: () -> Set[str]
         """Returns the list of classes that actually bear duration,
         i.e. contribute to onsets of their descendants in the precedence
         graph."""
@@ -246,8 +250,10 @@ class InferenceEngineConstants(object):
 
     @staticmethod
     def interpret_numerals(numerals):
+        from muscima.cropobject import CropObject
+        # type: (List[CropObject]) -> int
         """Returns the given numeral CropObject as a number, left to right."""
-        for n in numerals:
+        for n in numerals:  # type: CropObject
             if n.clsname not in InferenceEngineConstants.NUMERALS:
                 raise ValueError('Symbol {0} is not a numeral!'.format(n.uid))
         n_str = ''.join([n.clsname[-1]

--- a/muscima/io.py
+++ b/muscima/io.py
@@ -257,7 +257,7 @@ import logging
 import os
 
 import collections
-from typing import List
+from typing import List, Tuple, Optional
 
 from lxml import etree
 
@@ -485,6 +485,7 @@ def parse_cropobject_list(filename):
 
 
 def validate_cropobjects_graph_structure(cropobjects):
+    # type: (List[CropObject]) -> bool
     """Check that the graph defined by the ``inlinks`` and ``outlinks``
     in the given list of CropObjects is valid: no relationships
     leading from or to objects with non-existent ``objid``s.
@@ -513,6 +514,7 @@ def validate_cropobjects_graph_structure(cropobjects):
 
 
 def validate_document_graph_structure(cropobjects):
+    # type: (List[CropObject]) -> bool
     """Check that the graph defined by the ``inlinks`` and ``outlinks``
     in the given list of CropObjects is valid: no relationships
     leading from or to objects with non-existent ``objid``s.
@@ -551,6 +553,7 @@ def validate_document_graph_structure(cropobjects):
 
 
 def export_cropobject_graph(cropobjects, validate=True):
+    # type: (List[CropObject], bool) -> List[Tuple[int, int]]
     """Collects the inlink/outlink CropObject graph
     and returns it as a list of ``(from, to)`` edges.
 
@@ -575,6 +578,7 @@ def export_cropobject_graph(cropobjects, validate=True):
 
 
 def export_cropobject_list(cropobjects, docname=None, dataset_name=None):
+    # type: (List[CropObject], Optional[str], Optional[str]) -> str
     """Writes the CropObject data as a XML string. Does not write
     to a file -- use ``with open(output_file) as out_stream:`` etc.
 

--- a/muscima/io.py
+++ b/muscima/io.py
@@ -257,6 +257,8 @@ import logging
 import os
 
 import collections
+from typing import List
+
 from lxml import etree
 
 from muscima.cropobject import CropObject
@@ -270,6 +272,7 @@ __author__ = "Jan Hajic jr."
 
 
 def parse_cropobject_list(filename):
+    # type: (str) -> List[CropObject]
     """From a xml file with a CropObjectList as the top element, parse
     a list of CropObjects. (See ``CropObject`` class documentation
     for a description of the XMl format.)
@@ -412,7 +415,6 @@ def parse_cropobject_list(filename):
             if o_s_text is not None:
                 outlinks = list(map(int, o_s_text.split(' ')))
 
-
         #################################
         # Decode the data.
         data = cropobject.findall('Data')
@@ -425,7 +427,7 @@ def parse_cropobject_list(filename):
                 value_type = data_item.get('type')
                 value = data_item.text
 
-                #logging.debug('Creating data entry: key={0}, type={1},'
+                # logging.debug('Creating data entry: key={0}, type={1},'
                 #              ' value={2}'.format(key, value_type, value))
 
                 if value_type == 'int':

--- a/muscima/io.py
+++ b/muscima/io.py
@@ -631,6 +631,7 @@ def export_cropobject_list(cropobjects, docname=None, dataset_name=None):
 # Parsing CropObjectClass lists, mostly for grammars.
 
 def parse_cropobject_class_list(filename):
+    # type: (str) -> List[CropObjectClass]
     """From a xml file with a MLClassList as the top element,
     extract the list of :class:`CropObjectClass` objects. Use
     this
@@ -648,12 +649,12 @@ def parse_cropobject_class_list(filename):
 
 
 def export_cropobject_class_list(cropobject_classes):
+    # type: (List[CropObjectClass]) -> str
     """Writes the CropObject data as a XML string. Does not write
     to a file -- use ``with open(output_file) as out_stream:`` etc.
 
-    :param cropobjects: A list of CropObject instances.
+    :param cropobject_classes: A list of CropObjectClass instances.
     """
-    # This is the data string, the rest is formalities
     cropobject_classes_string = '\n'.join([str(c) for c in cropobject_classes])
 
     lines = list()

--- a/muscima/stafflines.py
+++ b/muscima/stafflines.py
@@ -19,7 +19,6 @@ from muscima.graph import NotationGraph, find_noteheads_on_staff_linked_to_ledge
 from muscima.inference_engine_constants import InferenceEngineConstants as _CONST
 from muscima.utils import compute_connected_components
 
-
 __version__ = "0.0.1"
 __author__ = "Jan Hajic jr."
 
@@ -77,7 +76,7 @@ def merge_staffline_segments(cropobjects, margin=10):
     """
     already_processed_stafflines = [c for c in cropobjects
                                     if (c.clsname == _CONST.STAFFLINE_CLSNAME) and
-                                        __has_parent_staff(c, cropobjects)]
+                                    __has_parent_staff(c, cropobjects)]
     # margin is used to avoid the stafflines touching the edges,
     # which could perhaps break some assumptions down the line.
     old_staffline_cropobjects = [c for c in cropobjects
@@ -242,7 +241,7 @@ def staff_bboxes_and_masks_from_staffline_bboxes_and_image(staffline_bboxes, mas
 
     n_stafflines = len(staffline_bboxes)
     for i in range(n_stafflines // 5):
-        _sbb = staffline_bboxes[5*i:5*(i+1)]
+        _sbb = staffline_bboxes[5 * i:5 * (i + 1)]
         _st = min([bb[0] for bb in _sbb])
         _sl = min([bb[1] for bb in _sbb])
         _sb = max([bb[2] for bb in _sbb])
@@ -293,7 +292,7 @@ def build_staff_cropobjects(cropobjects):
     Assumes the stafflines have already been merged."""
     stafflines = [c for c in cropobjects
                   if c.clsname == _CONST.STAFFLINE_CLSNAME and
-                    not __has_parent_staff(c, cropobjects)]
+                  not __has_parent_staff(c, cropobjects)]
     if len(stafflines) == 0:
         return []
 
@@ -309,13 +308,13 @@ def build_staff_cropobjects(cropobjects):
 
     n_stafflines = len(stafflines)
     for i in range(n_stafflines // 5):
-        _sbb = staffline_bboxes[5*i:5*(i+1)]
+        _sbb = staffline_bboxes[5 * i:5 * (i + 1)]
         _st = min([bb[0] for bb in _sbb])
         _sl = min([bb[1] for bb in _sbb])
         _sb = max([bb[2] for bb in _sbb])
         _sr = max([bb[3] for bb in _sbb])
         staff_bboxes.append((_st, _sl, _sb, _sr))
-        staff_masks.append(canvas[_st-_t:_sb-_t, _sl-_l:_sr-_l])
+        staff_masks.append(canvas[_st - _t:_sb - _t, _sl - _l:_sr - _l])
 
     logging.info('Creating staff CropObjects')
     next_objid = max([c.objid for c in cropobjects]) + 1
@@ -417,8 +416,8 @@ def build_staffspace_cropobjects(cropobjects):
             logging.debug(canvas.shape)
             logging.debug('l={0}, dl1={1}, dl2={2}, r={3}, dr1={4}, dr2={5}'
                           ''.format(l, dl1, dl2, r, dr1, dr2))
-            #canvas[:s1.height, :] += s1.mask[:, dl1:s1.width-dr1]
-            #canvas[-s2.height:, :] += s2.mask[:, dl2:s2.width-dr2]
+            # canvas[:s1.height, :] += s1.mask[:, dl1:s1.width-dr1]
+            # canvas[-s2.height:, :] += s2.mask[:, dl2:s2.width-dr2]
 
             # We have to deal with staffline interruptions.
             # One way to do this
@@ -443,8 +442,8 @@ def build_staffspace_cropobjects(cropobjects):
             # We now take the intersection of s1_below and s2_above.
             # If there is empty space in the middle, we fill it in.
             staffspace_mask = numpy.ones(canvas.shape)
-            staffspace_mask[s1_t:s1_b, :] -= (1 - s1_below[:, dl1:s1.width-dr1])
-            staffspace_mask[s2_t:s2_b, :] -= (1 - s2_above[:, dl2:s2.width-dr2])
+            staffspace_mask[s1_t:s1_b, :] -= (1 - s1_below[:, dl1:s1.width - dr1])
+            staffspace_mask[s2_t:s2_b, :] -= (1 - s2_above[:, dl2:s2.width - dr2])
 
             ss_top = s1.top
             ss_bottom = s2.bottom
@@ -508,7 +507,7 @@ def build_staffspace_cropobjects(cropobjects):
         bsl = sorted_stafflines[-1]
         bsl_heights = bsl.mask.sum(axis=0)
 
-        lss_top = bss.bottom # + max(bsl_heights)
+        lss_top = bss.bottom  # + max(bsl_heights)
         lss_left = bss.left
         lss_width = bss.width
         lss_height = int(bss.height / 1.2)
@@ -643,7 +642,7 @@ def add_staff_relationships(cropobjects,
     stafflines = [c for c in cropobjects if c.clsname == _CONST.STAFFLINE_CLSNAME]
     stafflines = sorted(stafflines, key=lambda c: c.top)
     staffspaces = [c for c in cropobjects if c.clsname == _CONST.STAFFSPACE_CLSNAME]
-    staffspaces= sorted(staffspaces, key=lambda c: c.top)
+    staffspaces = sorted(staffspaces, key=lambda c: c.top)
     staves = [c for c in cropobjects if c.clsname == _CONST.STAFF_CLSNAME]
     staves = sorted(staves, key=lambda c: c.top)
 
@@ -734,7 +733,7 @@ def add_staff_relationships(cropobjects,
                                      key=lambda ss: min((ll_max_dist.bottom - ss.top) ** 2,
                                                         (ll_max_dist.top - ss.bottom) ** 2))
                 distance_of_closest_staff = (ll_max_dist.top + ll_max_dist.bottom) / 2 \
-                                    - (staff_min_dist.top + staff_min_dist.bottom) / 2
+                                            - (staff_min_dist.top + staff_min_dist.bottom) / 2
                 if numpy.abs(distance_of_closest_staff) > (50 + 0.5 * staff_min_dist.height):
                     logging.debug('Trying to join notehead with ledger line to staff,'
                                   ' but the distance is larger than 50. Notehead: {0},'
@@ -766,9 +765,9 @@ def add_staff_relationships(cropobjects,
 
             if c.objid < 10:
                 logging.info('Notehead {0} ({1}): overlaps {2} stafflines'.format(c.uid,
-                                                                                   c.bounding_box,
-                                                                                   len(overlapped_stafflines),
-                                                                                   ))
+                                                                                  c.bounding_box,
+                                                                                  len(overlapped_stafflines),
+                                                                                  ))
 
             if len(overlapped_stafflines) == 1:
                 s = overlapped_stafflines[0]
@@ -873,4 +872,3 @@ def add_staff_relationships(cropobjects,
 
     ##########################################################################
     return cropobjects
-

--- a/muscima/stafflines.py
+++ b/muscima/stafflines.py
@@ -13,6 +13,7 @@ import pprint
 import numpy
 from skimage.filters import gaussian
 from skimage.morphology import watershed
+from typing import List
 
 from muscima.cropobject import CropObject, cropobjects_on_canvas, link_cropobjects
 from muscima.graph import NotationGraph, find_noteheads_on_staff_linked_to_ledger_line
@@ -27,6 +28,7 @@ __author__ = "Jan Hajic jr."
 
 
 def __has_parent_staff(c, cropobjects):
+    # type: (CropObject, List[CropObject]) -> bool
     _cdict = {c.objid: c for c in cropobjects}
     staff_inlinks = [_cdict[i] for i in c.inlinks
                      if _cdict[i].clsname == _CONST.STAFF_CLSNAME]
@@ -34,6 +36,7 @@ def __has_parent_staff(c, cropobjects):
 
 
 def __has_child_staffspace(staff, cropobjects):
+    # type: (CropObject, List[CropObject]) -> bool
     _cdict = {c.objid: c for c in cropobjects}
     staffline_outlinks = [_cdict[i] for i in staff.outlinks
                           if _cdict[i].clsname == _CONST.STAFFSPACE_CLSNAME]
@@ -41,6 +44,7 @@ def __has_child_staffspace(staff, cropobjects):
 
 
 def __has_neighbor_staffspace(staffline, cropobjects):
+    # type: (CropObject, List[CropObject]) -> bool
     _cdict = {c.objid: c for c in cropobjects}
     # Find parent staff
     if not __has_parent_staff(staffline, cropobjects):
@@ -58,6 +62,7 @@ def __has_neighbor_staffspace(staffline, cropobjects):
 
 
 def merge_staffline_segments(cropobjects, margin=10):
+    # type: (List[CropObject], int) -> List[CropObject]
     """Given a list of CropObjects that contain some staffline
     objects, generates a new list where the stafflines
     are merged based on their horizontal projections.

--- a/muscima/stafflines.py
+++ b/muscima/stafflines.py
@@ -13,7 +13,7 @@ import pprint
 import numpy
 from skimage.filters import gaussian
 from skimage.morphology import watershed
-from typing import List
+from typing import List, Tuple
 
 from muscima.cropobject import CropObject, cropobjects_on_canvas, link_cropobjects
 from muscima.graph import NotationGraph, find_noteheads_on_staff_linked_to_ledger_line
@@ -140,6 +140,7 @@ def merge_staffline_segments(cropobjects, margin=10):
 
 
 def staffline_bboxes_and_masks_from_horizontal_merge(mask):
+    # type: (numpy.ndarray) -> (List[Tuple[int,int,int,int]],List[numpy.ndarray])
     """Returns a list of staff_line bboxes and masks
      computed from the input mask, with
     each set of connected components in the mask that has at least
@@ -236,7 +237,9 @@ def staffline_bboxes_and_masks_from_horizontal_merge(mask):
     return staffline_bboxes, staffline_masks
 
 
-def staff_bboxes_and_masks_from_staffline_bboxes_and_image(staffline_bboxes, mask):
+def staff_bboxes_and_masks_from_staffline_bboxes_and_image(staffline_bboxes, image):
+    # type: (List[Tuple[int,int,int,int]],numpy.ndarray) -> (List[Tuple[int,int,int,int]], List[numpy.ndarray])
+
     logging.warning('Creating staff bboxes and masks.')
 
     #  - Go top-down and group the stafflines by five to get staves.
@@ -252,7 +255,7 @@ def staff_bboxes_and_masks_from_staffline_bboxes_and_image(staffline_bboxes, mas
         _sb = max([bb[2] for bb in _sbb])
         _sr = max([bb[3] for bb in _sbb])
         staff_bboxes.append((_st, _sl, _sb, _sr))
-        staff_masks.append(mask[_st:_sb, _sl:_sr])
+        staff_masks.append(image[_st:_sb, _sl:_sr])
 
     logging.warning('Total staffs: {0}'.format(len(staff_bboxes)))
 
@@ -260,6 +263,7 @@ def staff_bboxes_and_masks_from_staffline_bboxes_and_image(staffline_bboxes, mas
 
 
 def staffline_surroundings_mask(staffline_cropobject):
+    # type: (CropObject) -> (numpy.ndarray, numpy.ndarray)
     """Find the parts of the staffline's bounding box which lie
     above or below the actual staffline.
 
@@ -290,7 +294,8 @@ def staffline_surroundings_mask(staffline_cropobject):
 
 
 def build_staff_cropobjects(cropobjects):
-    """Derives staff objects from staffline objcets.
+    # type: (List[CropObject]) -> List[CropObject]
+    """Derives staff objects from staffline objects.
 
     Assumes each staff has 5 stafflines.
 
@@ -349,6 +354,7 @@ def build_staff_cropobjects(cropobjects):
 
 
 def build_staffspace_cropobjects(cropobjects):
+    # type: (List[CropObject]) -> List[CropObject]
     """Creates the staffspace objects based on stafflines
     and staffs. There is a staffspace between each two stafflines,
     one on the top side of each staff, and one on the bottom

--- a/muscima/utils.py
+++ b/muscima/utils.py
@@ -5,7 +5,6 @@ from __future__ import division
 import logging
 
 import numpy
-from muscima.cropobject import CropObject
 from skimage.measure import label
 from typing import Dict, List, Tuple
 
@@ -68,6 +67,7 @@ def compute_connected_components(image):
 
 
 def resolve_notehead_wrt_staffline(notehead, staffline_or_ledger_line):
+    from muscima.cropobject import CropObject
     # type: (CropObject, CropObject) -> int
     """Resolves the relative vertical position of the notehead with respect
     to the given staff_line or ledger_line object. Returns -1 if notehead
@@ -137,6 +137,7 @@ def resolve_notehead_wrt_staffline(notehead, staffline_or_ledger_line):
 
 
 def is_notehead_on_line(notehead, line_obj):
+    from muscima.cropobject import CropObject
     # type: (CropObject, CropObject) -> bool
     """Check whether given notehead is positioned on the line object."""
     if line_obj.clsname not in _CONST.STAFFLINE_LIKE_CROPOBJECT_CLSNAMES:

--- a/muscima/utils.py
+++ b/muscima/utils.py
@@ -4,7 +4,10 @@ from __future__ import division
 
 import logging
 
+import numpy
+from muscima.cropobject import CropObject
 from skimage.measure import label
+from typing import Dict, List, Tuple
 
 from muscima.inference_engine_constants import InferenceEngineConstants as _CONST
 
@@ -16,6 +19,7 @@ __author__ = "Jan Hajic jr."
 
 
 def connected_components2bboxes(labels):
+    # type: (List[List[int]]) -> Dict[int,Tuple[int, int, int, int]]
     """Returns a dictionary of bounding boxes (upper left c., lower right c.)
     for each label.
 
@@ -38,10 +42,10 @@ def connected_components2bboxes(labels):
         lies exactly within labels[xmin:xmax, ymin:ymax].
     """
     bboxes = {}
-    for x, row in enumerate(labels):
-        for y, l in enumerate(row):
+    for x, row in enumerate(labels):  # type: int, List[int]
+        for y, l in enumerate(row):  # type: int, int
             if l not in bboxes:
-                bboxes[l] = [x, y, x+1, y+1]
+                bboxes[l] = [x, y, x + 1, y + 1]
             else:
                 box = bboxes[l]
                 if x < box[0]:
@@ -56,6 +60,7 @@ def connected_components2bboxes(labels):
 
 
 def compute_connected_components(image):
+    # type: (numpy.ndarray) -> (int, numpy.ndarray, Dict[int,Tuple[int, int, int, int]])
     labels = label(image, background=0)
     cc = int(labels.max())
     bboxes = connected_components2bboxes(labels)
@@ -63,6 +68,7 @@ def compute_connected_components(image):
 
 
 def resolve_notehead_wrt_staffline(notehead, staffline_or_ledger_line):
+    # type: (CropObject, CropObject) -> int
     """Resolves the relative vertical position of the notehead with respect
     to the given staff_line or ledger_line object. Returns -1 if notehead
     is *below* staffline, 0 if notehead is *on* staffline, and 1 if notehead
@@ -120,17 +126,18 @@ def resolve_notehead_wrt_staffline(notehead, staffline_or_ledger_line):
             output_position = -1
 
         else:
-            logging.warn('Strange notehead {0} vs. ledger line {1}'
-                         ' situation: bbox notehead {2}, LL {3}.'
-                         ' Note that the output position is unusable;'
-                         ' pleasre re-do this attachment manually.'
-                         ''.format(notehead.uid, ll.uid,
-                                   notehead.bounding_box,
-                                   ll.bounding_box))
+            logging.warning('Strange notehead {0} vs. ledger line {1}'
+                            ' situation: bbox notehead {2}, LL {3}.'
+                            ' Note that the output position is unusable;'
+                            ' please re-do this attachment manually.'
+                            ''.format(notehead.uid, ll.uid,
+                                      notehead.bounding_box,
+                                      ll.bounding_box))
     return output_position
 
 
 def is_notehead_on_line(notehead, line_obj):
+    # type: (CropObject, CropObject) -> bool
     """Check whether given notehead is positioned on the line object."""
     if line_obj.clsname not in _CONST.STAFFLINE_LIKE_CROPOBJECT_CLSNAMES:
         raise ValueError('Cannot resolve relative position of notehead'

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,9 @@ midiutil>=1.2.1
 midi2audio>=0.1.1
 future
 
+# Making type-hinting work in Python 2
+typing
+
 # Libraries to integrating code-coverage reporting
 python-coveralls
 codecov

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,7 @@ typing
 # Libraries to integrating code-coverage reporting
 python-coveralls
 codecov
+
+# For inference and playing pieces
+midi2audio
+midiutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,6 @@ pytest-cov
 scikit-image
 scikit-learn
 matplotlib
-midiutil>=1.2.1
-midi2audio>=0.1.1
 future
 
 # Making type-hinting work in Python 2
@@ -17,5 +15,5 @@ python-coveralls
 codecov
 
 # For inference and playing pieces
-midi2audio
-midiutil
+midiutil>=1.2.1
+midi2audio>=0.1.1


### PR DESCRIPTION
- Added type-hints to many functions from the code-base.
- Auto-formatted files
- Changed to log.warning instead of log.warn, which is deprecated