### PR TITLE
Dataset init fix

### DIFF
--- a/muscima/dataset.py
+++ b/muscima/dataset.py
@@ -104,12 +104,12 @@ class CVC_MUSCIMA(object):
                             ' a valid root: the path {0} does not lead to'
                             ' a directory.'.format(root))
 
+        self.root = root
+        
         if validate and not self.validate(fail_early=True):
             raise ValueError('CVC_MUSCIMA innstance with root {0} does not'
                              ' represent a valid CVC-MUSCIMA dataset copy.'
                              ''.format(self.root))
-
-        self.root = root
 
     def imfile(self, page, writer, distortion='ideal', mode='full'):
         # type: (int, int, str, str) -> str

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -1,0 +1,15 @@
+import unittest
+
+from muscima.dataset import CVC_MUSCIMA
+
+
+class CVC_MUSCIMATest(unittest.TestCase):
+    def test_init(self):
+        root = "/muscima/v1.0/data/images/" # path to the dataset
+        
+        CVC_MUSCIMA(root=root, validate=False) # without validation
+        CVC_MUSCIMA(root=root, validate=True) # with validation
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Class variable root is part of `self.validate(fail_early=True)` call but is set after the function is called, causing error. I have moved the variable assignment before the function call. Furthermore I have added a simple unit test, that fails before the fix and passes afterwards.