### PR TITLE
Adapdt parser to handle other datasets (DoReMi)

### DIFF
--- a/muscima/cropobject.py
+++ b/muscima/cropobject.py
@@ -1021,6 +1021,8 @@ class CropObject(object):
         if mask_string == 'None':
             return None
 
+        mask_string = mask_string.rstrip() # Remove trailing whitespace (present in the DoReMi dataset)
+
         values = []
         for kv in mask_string.split(' '):
             k_string, v_string = kv.split(':')

--- a/muscima/io.py
+++ b/muscima/io.py
@@ -327,7 +327,12 @@ def parse_cropobject_list(filename):
     logging.debug('XML parsed.')
     cropobject_list = []
 
-    for i, cropobject in enumerate(root.iter('CropObject')):
+    node_tag = 'CropObject'
+
+    if not list(root.iter(node_tag)):
+        node_tag = 'Node'
+
+    for i, cropobject in enumerate(root.iter(node_tag)):
         ######################################################
         # Parsing one CropObject
         logging.debug('Parsing CropObject {0}'.format(i))


### PR DESCRIPTION
Adapt the xml parser to other datasets such as the [DoReMi dataset] (https://elonashatri.github.io/doremi-dataset.html), a larger, more recent dataset for OMR. Its encoding is slightly different from that of muscima++: node tags are 'Node' insthead of 'CropObject' and there are trailing whitespace in the object masks.